### PR TITLE
fix: bump ckb-js-vm testnet script info

### DIFF
--- a/src/scripts/public.ts
+++ b/src/scripts/public.ts
@@ -148,7 +148,7 @@ export const TESTNET_SYSTEM_SCRIPTS: SystemScriptsRecord = {
         {
           cellDep: {
             outPoint: {
-              txHash: '0x9f6558e91efa7580bfe97830d11cd94ca5d614bbf4a10b36f3a5b9d092749353',
+              txHash: '0x756fdaf0d1ba1d2e03dc13c71c967b24021bc054893a766ccee6879c468892d2',
               index: 0,
             },
             depType: 'code',


### PR DESCRIPTION
new deployment on testnet for ckb-js-vm:

https://github.com/nervosnetwork/ckb-js-vm/blob/main/deployment/testnet/20250320/migrations/2025-12-09-090112.json