### PR TITLE
chore(core): bump nostr-lock mainnet cell deps

### DIFF
--- a/src/scripts/public.ts
+++ b/src/scripts/public.ts
@@ -291,7 +291,7 @@ export const MAINNET_SYSTEM_SCRIPTS: SystemScriptsRecord = {
         {
           cellDep: {
             outPoint: {
-              txHash: '0x1911208b136957d5f7c1708a8835edfe8ae1d02700d5cb2c3a6aacf4d5906306',
+              txHash: '0x99b116dd1e4f1fa903b70112ae672c18bb34241d3d03a9ad555cd2a611be7327',
               index: 0,
             },
             depType: 'code',


### PR DESCRIPTION
A new mainnet deployment on nostr-lock script has been taking effect to upgrade multisig signers. No contract code changes in this deployment.

This PR bumps the nostr-lock mainnet config in public script info. More details about the deployment can be found here:

- https://github.com/cryptape/nostr-binding/commit/eef134e0a09dd07ccc367eb4eca84c1a5a73fb8b#diff-4f41397d5fbdd8ce3ab1319d5b3c550296ecbd43050cf95d4baa36d5273d3a24L50