### PR TITLE
fix(install): force x86_64 architecture on Windows (#399)

### DIFF
--- a/.changeset/tired-jobs-find.md
+++ b/.changeset/tired-jobs-find.md
@@ -1,0 +1,16 @@
+---
+'@offckb/cli': patch
+---
+
+fix(install): force x86_64 architecture on Windows
+
+CKB only provides x86_64 binaries for Windows, not aarch64.
+When Windows ARM devices reported 'arm64' via os.arch(), the code
+tried to download a non-existent 'aarch64-pc-windows-msvc' binary,
+resulting in a 404 error.
+
+This fix forces all Windows systems to use x86_64, which:
+
+- Works correctly on Windows x64
+- Works via emulation on Windows ARM devices
+- Matches the only Windows binary CKB provides

--- a/src/node/install.ts
+++ b/src/node/install.ts
@@ -143,6 +143,12 @@ function getOS(): string {
 }
 
 function getArch(): string {
+  // CKB only provides x86_64 binaries for Windows
+  // Return x86_64 for all Windows systems (works on ARM via emulation)
+  if (os.platform() === 'win32') {
+    return 'x86_64';
+  }
+
   const arch = os.arch();
   if (arch === 'x64') {
     return 'x86_64';


### PR DESCRIPTION
* fix(install): force x86_64 architecture on Windows

CKB only provides x86_64 binaries for Windows, not aarch64. When Windows ARM devices reported 'arm64' via os.arch(), the code tried to download a non-existent 'aarch64-pc-windows-msvc' binary, resulting in a 404 error.

This fix forces all Windows systems to use x86_64, which:
- Works correctly on Windows x64
- Works via emulation on Windows ARM devices
- Matches the only Windows binary CKB provides

Fixes #issue with Windows ARM architecture detection

* chore: add changeset