### PR TITLE
chore: bump default CKB version to 0.207.0

### DIFF
--- a/.changeset/silver-eels-divide.md
+++ b/.changeset/silver-eels-divide.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Bump default CKB version to 0.207.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offckb/cli",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "ckb development network for your first try",
   "author": "CKB EcoFund",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offckb/cli",
-  "version": "0.4.7",
+  "version": "0.4.6",
   "description": "ckb development network for your first try",
   "author": "CKB EcoFund",
   "license": "MIT",

--- a/src/cfg/setting.ts
+++ b/src/cfg/setting.ts
@@ -62,7 +62,7 @@ export const defaultSettings: Settings = {
   proxy: undefined,
   bins: {
     rootFolder: path.resolve(dataPath, 'bins'),
-    defaultCKBVersion: '0.205.0',
+    defaultCKBVersion: '0.207.0',
     downloadPath: path.resolve(cachePath, 'download'),
   },
   devnet: {


### PR DESCRIPTION
Bump default CKB version from 0.205.0 to 0.207.0 (latest release, 2026-06-10).\n\n- Update `defaultCKBVersion` in `src/cfg/setting.ts`\n- Bump package version 0.4.6 → 0.4.7\n- Add changeset