### PR TITLE
chore(release): bump version to 0.4.7

### DIFF
--- a/.changeset/bump-ccc-core-ws-fix.md
+++ b/.changeset/bump-ccc-core-ws-fix.md
@@ -1,5 +1,0 @@
----
-"@offckb/cli": patch
----
-
-Bump @ckb-ccc/core to 1.14.0 to fix the ws vulnerability (ws >= 8.21.0).

--- a/.changeset/silver-eels-divide.md
+++ b/.changeset/silver-eels-divide.md
@@ -1,5 +1,0 @@
----
-'@offckb/cli': patch
----
-
-Bump default CKB version to 0.207.0

--- a/.changeset/wise-candies-stop.md
+++ b/.changeset/wise-candies-stop.md
@@ -1,9 +1,0 @@
----
-'@offckb/cli': minor
----
-
-Replace ckb-transaction-dumper with ccc-based implementation
-
-- Rewrite transaction dumper to use ccc Client and molecule codecs
-- Implement dep_group unpacking using ccc.mol
-- Remove ckb-transaction-dumper npm dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @offckb/cli
 
+## 0.4.7
+
+### Patch Changes
+
+- 1c17600: Bump @ckb-ccc/core to 1.14.0 to fix the ws vulnerability (ws >= 8.21.0).
+- a687c6f: Bump default CKB version to 0.207.0
+- 3da9777: Replace ckb-transaction-dumper with ccc-based implementation
+
+  - Rewrite transaction dumper to use ccc Client and molecule codecs
+  - Implement dep_group unpacking using ccc.mol
+  - Remove ckb-transaction-dumper npm dependency
+
 ## 0.4.6
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offckb/cli",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "ckb development network for your first try",
   "author": "CKB EcoFund",
   "license": "MIT",


### PR DESCRIPTION
## Changes

- Consume pending changesets via changeset version
- Bump version 0.4.6 to 0.4.7 (patch)

### Included changes:
- Bump @ckb-ccc/core to 1.14.0 to fix ws vulnerability
- Bump default CKB version to 0.207.0
- Replace ckb-transaction-dumper with ccc-based implementation