### PR TITLE
chore(deps): override form-data to 4.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "secp256k1"
-    ]
+    ],
+    "overrides": {
+      "form-data@>=4.0.0 <4.0.6": "4.0.6"
+    }
   },
   "scripts": {
     "build": "node scripts/build.js",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "secp256k1"
-    ],
-    "overrides": {
-      "form-data@>=4.0.0 <4.0.6": "4.0.6"
-    }
-  },
   "scripts": {
     "build": "node scripts/build.js",
     "start": "ts-node-dev --transpile-only src/cli.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data@>=4.0.0 <4.0.6: 4.0.6
+
 importers:
 
   .:
@@ -1702,8 +1705,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.4:
-    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -1822,6 +1825,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hmac-drbg@1.0.1:
@@ -4090,7 +4097,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 20.17.24
-      form-data: 4.0.4
+      form-data: 4.0.6
 
   '@types/node@12.20.55': {}
 
@@ -4727,7 +4734,7 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   escalade@3.2.0: {}
 
@@ -4980,12 +4987,12 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.4:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -5027,7 +5034,7 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   get-package-type@0.1.0: {}
@@ -5107,6 +5114,10 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+overrides:
+  "form-data@>=4.0.0 <4.0.6": "4.0.6"
+
+onlyBuiltDependencies:
+  - secp256k1


### PR DESCRIPTION
Force the transitive "form-data" dependency to the patched version 4.0.6 to resolve the CRLF injection vulnerability (GHSA-7m2j-8qp9-m8jw).\n\nChanges:\n- Added a pnpm override in "pnpm-workspace.yaml" so all resolutions of form-data in the range ">=4.0.0 <4.0.6" resolve to 4.0.6.\n- Updated "pnpm-lock.yaml" so the only form-data version is 4.0.6.\n- Moved the existing "onlyBuiltDependencies" config from package.json to pnpm-workspace.yaml because pnpm 10 reads these settings from the workspace file.\n\nTests pass locally with pnpm 10.34.4.