### PR TITLE
chore(release): bump version to 0.4.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @offckb/cli
 
+## 0.4.8
+
+### Patch Changes
+
+- Override `form-data@>=4.0.0 <4.0.6` to `4.0.6` to fix CRLF injection (GHSA).
+- Override `hono@<4.12.25` to `4.12.25` to fix CORS origin reflection with credentials.
+
 ## 0.4.7
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offckb/cli",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "ckb development network for your first try",
   "author": "CKB EcoFund",
   "license": "MIT",


### PR DESCRIPTION
Bumps the package version to `0.4.8` (patch) and updates the changelog with the recent dependency security overrides.\n\nChanges since 0.4.7:\n- Override `form-data@>=4.0.0 <4.0.6` to `4.0.6` (CRLF injection fix).\n- Override `hono@<4.12.25` to `4.12.25` (CORS origin reflection fix).\n\nTests passed locally (`pnpm test:ci`: 40 passed, 7 skipped).