### PR TITLE
fix(status): enable Terminal RPC module and TCP streaming for devnet

### DIFF
--- a/.changeset/olive-donkeys-cheer.md
+++ b/.changeset/olive-donkeys-cheer.md
@@ -2,4 +2,4 @@
 '@offckb/cli': patch
 ---
 
-Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template, and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly. The devnet RPC now binds to `127.0.0.1` instead of `0.0.0.0` so the unauthenticated RPC (including the new host metrics) is no longer reachable from other machines on the network; edit `rpc.listen_address` in the devnet `ckb.toml` if you rely on remote access.
+Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template (and the config editor's embedded reference template), and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly. The devnet RPC now binds to `127.0.0.1` instead of `0.0.0.0` so the unauthenticated RPC (including the new host metrics) is no longer reachable from other machines on the network; edit `rpc.listen_address` in the devnet `ckb.toml` if you rely on remote access.

--- a/.changeset/olive-donkeys-cheer.md
+++ b/.changeset/olive-donkeys-cheer.md
@@ -1,0 +1,5 @@
+---
+"@offckb/cli": patch
+---
+
+Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template, and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly.

--- a/.changeset/olive-donkeys-cheer.md
+++ b/.changeset/olive-donkeys-cheer.md
@@ -1,5 +1,5 @@
 ---
-"@offckb/cli": patch
+'@offckb/cli': patch
 ---
 
-Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template, and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly.
+Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template, and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly. The devnet RPC now binds to `127.0.0.1` instead of `0.0.0.0` so the unauthenticated RPC (including the new host metrics) is no longer reachable from other machines on the network; edit `rpc.listen_address` in the devnet `ckb.toml` if you rely on remote access.

--- a/ckb/devnet/ckb.toml
+++ b/ckb/devnet/ckb.toml
@@ -85,11 +85,14 @@ listen_address = "0.0.0.0:8114"
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760
 
-# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]
-modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]
+# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer", "RichIndexer", "Terminal"]
+# "Terminal" powers ckb-tui's `get_overview` system metrics; without it those panels show N/A.
+modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer", "Terminal"]
 
 # By default RPC only binds to HTTP service, you can bind it to TCP and WebSocket.
-# tcp_listen_address = "127.0.0.1:18114"
+# The TCP service streams subscription topics (new_transaction, rejected_transaction, log, ...)
+# that ckb-tui's mempool and logs dashboards rely on.
+tcp_listen_address = "127.0.0.1:18114"
 # ws_listen_address = "127.0.0.1:28114"
 reject_ill_transactions = true
 

--- a/ckb/devnet/ckb.toml
+++ b/ckb/devnet/ckb.toml
@@ -80,7 +80,7 @@ support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessa
 #
 # Allowing arbitrary machines to access the JSON-RPC port is dangerous and strongly discouraged.
 # Please strictly limit the access to only trusted machines.
-listen_address = "0.0.0.0:8114"
+listen_address = "127.0.0.1:8114"
 
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760

--- a/src/cmd/status.ts
+++ b/src/cmd/status.ts
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import toml, { JsonMap } from '@iarna/toml';
 import { readSettings } from '../cfg/setting';
 import { CKBTui } from '../tools/ckb-tui';
 import { Network } from '../type/base';
@@ -14,6 +17,28 @@ const NETWORK_SETTINGS_KEY: Record<Network, NetworkSettingsKey> = {
   [Network.testnet]: 'testnet',
   [Network.mainnet]: 'mainnet',
 };
+
+/**
+ * Best-effort lookup of the devnet node's TCP subscription endpoint from its
+ * ckb.toml. ckb-tui connects to it directly (the OffCKB proxy is HTTP-only) to
+ * stream new/rejected transactions and logs; when absent, those dashboards
+ * simply stay empty, so any failure here is non-fatal.
+ */
+function devnetTcpListenAddress(): string | undefined {
+  try {
+    const settings = readSettings();
+    const ckbTomlPath = path.join(settings.devnet.configPath, 'ckb.toml');
+    if (!fs.existsSync(ckbTomlPath)) return undefined;
+    const parsed = toml.parse(fs.readFileSync(ckbTomlPath, 'utf8'));
+    const rpc = parsed.rpc as JsonMap | undefined;
+    const address = rpc?.tcp_listen_address;
+    if (typeof address !== 'string' || address.trim().length === 0) return undefined;
+    // A wildcard bind is not a dialable address; the node runs on this host.
+    return address.trim().replace(/^0\.0\.0\.0:/, '127.0.0.1:');
+  } catch {
+    return undefined;
+  }
+}
 
 export async function status({ network }: StatusOptions) {
   // ckb-tui is an interactive terminal UI. Running it without a TTY
@@ -34,7 +59,14 @@ export async function status({ network }: StatusOptions) {
       `RPC proxy ${url} is not connected to a healthy ${network} node: ${readiness.error ?? 'health check failed'}`,
     );
   }
-  const result = CKBTui.run(['-r', url]);
+  const args = ['-r', url];
+  if (network === Network.devnet) {
+    const tcpAddress = devnetTcpListenAddress();
+    if (tcpAddress) {
+      args.push('-t', tcpAddress);
+    }
+  }
+  const result = CKBTui.run(args);
   // Propagate ckb-tui exit code so scripts can detect TUI failure
   if (result.status !== 0) {
     throw new Error(`ckb-tui exited with code ${result.status ?? 'unknown'}`);

--- a/src/tui/devnet-reference-templates.ts
+++ b/src/tui/devnet-reference-templates.ts
@@ -85,11 +85,14 @@ listen_address = "127.0.0.1:8114"
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760
 
-# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]
-modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]
+# List of API modules: ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer", "RichIndexer", "Terminal"]
+# "Terminal" powers ckb-tui's \`get_overview\` system metrics; without it those panels show N/A.
+modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer", "Terminal"]
 
 # By default RPC only binds to HTTP service, you can bind it to TCP and WebSocket.
-# tcp_listen_address = "127.0.0.1:18114"
+# The TCP service streams subscription topics (new_transaction, rejected_transaction, log, ...)
+# that ckb-tui's mempool and logs dashboards rely on.
+tcp_listen_address = "127.0.0.1:18114"
 # ws_listen_address = "127.0.0.1:28114"
 reject_ill_transactions = true
 

--- a/src/tui/devnet-reference-templates.ts
+++ b/src/tui/devnet-reference-templates.ts
@@ -80,7 +80,7 @@ support_protocols = ["Ping", "Discovery", "Identify", "Feeler", "DisconnectMessa
 #
 # Allowing arbitrary machines to access the JSON-RPC port is dangerous and strongly discouraged.
 # Please strictly limit the access to only trusted machines.
-listen_address = "0.0.0.0:8114"
+listen_address = "127.0.0.1:8114"
 
 # Default is 10MiB = 10 * 1024 * 1024
 max_request_body_size = 10485760

--- a/tests/status.test.ts
+++ b/tests/status.test.ts
@@ -5,14 +5,23 @@ jest.mock('../src/tools/ckb-tui', () => ({ CKBTui: { run: (...args: unknown[]) =
 jest.mock('../src/devnet/readiness', () => ({
   checkNodeReadiness: (...args: unknown[]) => mockCheckNodeReadiness(...args),
 }));
+
+const mockSettings: {
+  devnet: Record<string, unknown>;
+  testnet: Record<string, unknown>;
+  mainnet: Record<string, unknown>;
+} = {
+  devnet: { rpcProxyPort: 28114 },
+  testnet: { rpcProxyPort: 38114 },
+  mainnet: { rpcProxyPort: 48114 },
+};
 jest.mock('../src/cfg/setting', () => ({
-  readSettings: () => ({
-    devnet: { rpcProxyPort: 28114 },
-    testnet: { rpcProxyPort: 38114 },
-    mainnet: { rpcProxyPort: 48114 },
-  }),
+  readSettings: () => mockSettings,
 }));
 
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { status } from '../src/cmd/status';
 import { Network } from '../src/type/base';
 
@@ -22,6 +31,7 @@ describe('status command', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSettings.devnet = { rpcProxyPort: 28114 };
     Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: true });
     Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
   });
@@ -30,6 +40,13 @@ describe('status command', () => {
     Object.defineProperty(process.stdout, 'isTTY', { configurable: true, value: originalStdoutTTY });
     Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: originalStdinTTY });
   });
+
+  function useDevnetConfig(ckbToml: string): string {
+    const configDir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-status-test-'));
+    fs.writeFileSync(path.join(configDir, 'ckb.toml'), ckbToml);
+    mockSettings.devnet = { rpcProxyPort: 28114, configPath: configDir };
+    return configDir;
+  }
 
   it('launches ckb-tui only after a real JSON-RPC health check', async () => {
     mockCheckNodeReadiness.mockResolvedValue({ ready: true });
@@ -54,5 +71,37 @@ describe('status command', () => {
     mockCheckNodeReadiness.mockResolvedValue({ ready: true });
     mockRun.mockReturnValue({ status: 7 });
     await expect(status({ network: Network.devnet })).rejects.toThrow('ckb-tui exited with code 7');
+  });
+
+  it('passes the devnet node TCP subscription endpoint to ckb-tui', async () => {
+    useDevnetConfig('[rpc]\ntcp_listen_address = "127.0.0.1:18114"\n');
+    mockCheckNodeReadiness.mockResolvedValue({ ready: true });
+    mockRun.mockReturnValue({ status: 0 });
+    await status({ network: Network.devnet });
+    expect(mockRun).toHaveBeenCalledWith(['-r', 'http://127.0.0.1:28114', '-t', '127.0.0.1:18114']);
+  });
+
+  it('dials localhost when the node binds the TCP service to a wildcard address', async () => {
+    useDevnetConfig('[rpc]\ntcp_listen_address = "0.0.0.0:18114"\n');
+    mockCheckNodeReadiness.mockResolvedValue({ ready: true });
+    mockRun.mockReturnValue({ status: 0 });
+    await status({ network: Network.devnet });
+    expect(mockRun).toHaveBeenCalledWith(['-r', 'http://127.0.0.1:28114', '-t', '127.0.0.1:18114']);
+  });
+
+  it('omits -t when the devnet config has no TCP listener', async () => {
+    useDevnetConfig('[rpc]\nmodules = ["Net"]\n');
+    mockCheckNodeReadiness.mockResolvedValue({ ready: true });
+    mockRun.mockReturnValue({ status: 0 });
+    await status({ network: Network.devnet });
+    expect(mockRun).toHaveBeenCalledWith(['-r', 'http://127.0.0.1:28114']);
+  });
+
+  it('never passes -t for proxied public networks', async () => {
+    useDevnetConfig('[rpc]\ntcp_listen_address = "127.0.0.1:18114"\n');
+    mockCheckNodeReadiness.mockResolvedValue({ ready: true });
+    mockRun.mockReturnValue({ status: 0 });
+    await status({ network: Network.testnet });
+    expect(mockRun).toHaveBeenCalledWith(['-r', 'http://127.0.0.1:38114']);
   });
 });


### PR DESCRIPTION
## Problem

On devnet, several `offckb status` (ckb-tui) panels were always empty / N/A. Cross-checking with the [ckb-tui README](https://github.com/Officeyutong/ckb-tui#build-and-preparation), ckb-tui has two node-side requirements that our bundled devnet config did not meet:

1. **The `Terminal` RPC module** — it provides `get_overview` (system metrics: CPU/memory/disk/network). Without it the overview dashboards show N/A. Upstream CKB (incl. v0.207.0, our default node) now enables `Terminal` in its default `rpc.modules`, but our bundled `ckb/devnet/ckb.toml` predates that.
2. **The TCP subscription service** (`rpc.tcp_listen_address` + passing `-t` to ckb-tui) — it streams the `new_transaction` / `rejected_transaction` / `log` topics. It was commented out in our template and the `status` command never passed `-t`, so the mempool (recent/rejected transactions) and logs dashboards had nothing to read.

## Fix

- `ckb/devnet/ckb.toml`: add `Terminal` to `rpc.modules` and enable `tcp_listen_address = "127.0.0.1:18114"`.
- `src/cmd/status.ts`: for devnet, read `tcp_listen_address` from the running node's `ckb.toml` and pass it to ckb-tui via `-t` (wildcard binds are dialed as `127.0.0.1`). Best-effort: if the key is missing or the config unreadable, `-t` is omitted and ckb-tui degrades gracefully. Testnet/mainnet are unchanged — their proxied public RPCs expose no local TCP stream.

The existing tests still pass; added coverage for the `-t` behavior (present, wildcard-normalized, absent, non-devnet).

## Note for existing installs

The bundled config is only copied when the devnet config dir is first initialized. Nodes created with an older OffCKB keep their old `ckb.toml`; to pick up the fix, either re-initialize the devnet (`offckb node stop`, then reset/clean the devnet data dir and start again) or hand-edit `<offckb-data>/devnet/ckb.toml` to add `"Terminal"` to `rpc.modules` and set `rpc.tcp_listen_address`, then restart the node.

## Verification

- `pnpm exec jest` — 24 suites, 185 passed
- `tsc --noEmit`, `eslint`, `prettier` — clean