### PR TITLE
fix: default devnet log filter to info,ckb-script=debug

### DIFF
--- a/.changeset/devnet-log-filter-info.md
+++ b/.changeset/devnet-log-filter-info.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Change the default devnet log filter from `warn,ckb-script=debug` to `info,ckb-script=debug` in the `ckb.toml` / `ckb-miner.toml` templates (and the config editor's embedded reference templates). A healthy devnet produces almost no `warn`-level output, which left the `offckb status` Logs panel permanently empty and looked broken; `info` keeps the per-block log stream visible while `ckb-script=debug` still surfaces script execution details. Applies to newly initialized chains — edit `[logger] filter` in your existing devnet `ckb.toml` to opt in.

--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ offckb system-scripts --output <output-file-path>
 
 ### 6. Tweak Devnet Config {#tweak-devnet-config}
 
-By default, OffCKB use a fixed Devnet config. You can customize it, for example by modifying the default log level (`warn,ckb-script=debug`).
+By default, OffCKB use a fixed Devnet config. You can customize it, for example by modifying the default log level (`info,ckb-script=debug`).
 
 1. Open the interactive Devnet config editor:
 

--- a/ckb/devnet/ckb-miner.toml
+++ b/ckb/devnet/ckb-miner.toml
@@ -10,7 +10,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "warn,ckb-script=debug"
+filter = "info,ckb-script=debug"
 color = true
 log_to_file = true
 log_to_stdout = true

--- a/ckb/devnet/ckb.toml
+++ b/ckb/devnet/ckb.toml
@@ -10,7 +10,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "warn,ckb-script=debug"
+filter = "info,ckb-script=debug"
 color = true
 log_to_file = true
 log_to_stdout = true

--- a/src/tui/devnet-reference-templates.ts
+++ b/src/tui/devnet-reference-templates.ts
@@ -10,7 +10,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "warn,ckb-script=debug"
+filter = "info,ckb-script=debug"
 color = true
 log_to_file = true
 log_to_stdout = true
@@ -193,7 +193,7 @@ data_dir = "data"
 spec = { file = "specs/dev.toml" }
 
 [logger]
-filter = "warn,ckb-script=debug"
+filter = "info,ckb-script=debug"
 color = true
 log_to_file = true
 log_to_stdout = true


### PR DESCRIPTION
## Why

Live-testing `offckb status` on a fresh devnet (see #468 follow-up) showed the **Logs panel permanently empty** with the default config. The devnet template ships `filter = "warn,ckb-script=debug"`, and a healthy devnet produces almost no `warn`-level output — so the panel looks broken even though the whole Terminal-module pipeline works.

## What

- `ckb/devnet/ckb.toml`, `ckb/devnet/ckb-miner.toml`: `[logger] filter` → `info,ckb-script=debug`
- `src/tui/devnet-reference-templates.ts`: same change in both embedded reference templates used by the config editor
- `README.md`: update the default-log-level example
- Patch changeset included

`info` restores the per-block log stream in the Logs panel; keeping `ckb-script=debug` preserves script execution debug output for contract developers.

Existing chains are intentionally **not** migrated (their filter may be user-customized) — the changeset notes how to opt in.

## Verification

- Full suite: 28 suites / 220 passed
- tsc / eslint clean
- Manually verified on a live devnet that `info,ckb-script=debug` makes the ckb-tui Logs panel stream per-block entries with working level counters