### PR TITLE
chore: remove consumed v0.4.10 changeset

### DIFF
--- a/.changeset/olive-donkeys-cheer.md
+++ b/.changeset/olive-donkeys-cheer.md
@@ -1,5 +1,0 @@
----
-'@offckb/cli': patch
----
-
-Fix the `status` command showing missing data on devnet: enable the Terminal RPC module and the TCP listen address in the devnet `ckb.toml` template (and the config editor's embedded reference template), and pass the node's TCP listen address to ckb-tui so the system metrics, mempool, and log panels populate correctly. The devnet RPC now binds to `127.0.0.1` instead of `0.0.0.0` so the unauthenticated RPC (including the new host metrics) is no longer reachable from other machines on the network; edit `rpc.listen_address` in the devnet `ckb.toml` if you rely on remote access.


### PR DESCRIPTION
## What changed

- Remove `.changeset/olive-donkeys-cheer.md` from `master`.
- Leave `package.json` at `0.4.10` and keep the existing `0.4.10` changelog unchanged.

## Why

The status fix was merged independently into `master` in #463 and cherry-picked to `develop` in #464. The `develop` copy of the changeset was consumed when preparing `0.4.10` in #469, but merging `develop` back into `master` in #474 retained the independently-added `master` copy.

As a result, the `v0.4.10` tag workflow treated that stale changeset as unreleased work and attempted to generate `0.4.11`, causing the release check to fail before publishing to npm.

## Impact

After this merges, `master` no longer has an unreleased changeset and can be used as the corrected source for recreating the `v0.4.10` tag. This PR does not modify or delete the existing release or tag.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm changeset version` → `No unreleased changesets found, exiting.`
- Clean worktree after validation; no generated version or changelog changes.
