### PR TITLE
fix(status): bump ckb-tui to v0.1.4 and reinstall stale binaries

### DIFF
--- a/.changeset/ckb-tui-v0.1.4.md
+++ b/.changeset/ckb-tui-v0.1.4.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Bump the bundled ckb-tui from v0.1.3 to v0.1.4 for `offckb status`. The new release fixes a divide-by-zero panic in ckb-tui's data-sync thread when the connected node has no peers (Officeyutong/ckb-tui#13) — the normal state of a single-node devnet — which permanently froze the Overview, Mempool, Peers, and Blockchain panels within seconds of opening the TUI. SHA-256 digests for the v0.1.4 release assets are pinned in offckb, so the download stays verifiable.

--- a/src/cfg/setting.ts
+++ b/src/cfg/setting.ts
@@ -97,7 +97,7 @@ export const defaultSettings: Settings = {
       minVersion: '0.200.0',
     },
     ckbTui: {
-      version: 'v0.1.3',
+      version: 'v0.1.4',
     },
   },
 };

--- a/src/tools/ckb-tui.ts
+++ b/src/tools/ckb-tui.ts
@@ -15,13 +15,38 @@ const EXTRACT_TIMEOUT_MS = 60_000;
 const STRICT_VERSION_REGEX = /^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 
 // Independently pinned digests for the default release. Keeping these in
-// offckb makes the default installation verifiable even though ckb-tui v0.1.3
+// offckb makes the default installation verifiable even though ckb-tui v0.1.4
 // did not upload a checksums-sha256.txt asset.
 const KNOWN_SHA256: Record<string, Record<string, string>> = {
+  'v0.1.4': {
+    'ckb-tui-with-node-linux-amd64.tar.gz': 'eaed2cfbd55c4ee78493200bf33b5b120ec2625df4e7041b048cd87d51801cbd',
+    'ckb-tui-with-node-macos-aarch64.tar.gz': '911aa3f1266fd333d2566e798df888ffb105b35da7d9328d7b715f3be7adc246',
+    'ckb-tui-with-node-windows-amd64.zip': 'aab24826e0951188f72ddc1c128148899c54237dc9cc4bd5929038504cdd0dfa',
+  },
   'v0.1.3': {
     'ckb-tui-with-node-linux-amd64.tar.gz': '33455cefe2c016149fa8fa3abde7960b348d4606afef9279d787ac8a8b59956f',
     'ckb-tui-with-node-macos-aarch64.tar.gz': 'de18107ec179ced03608da956013e38ae82e6c1fae588f12c17d138ee6ee072c',
     'ckb-tui-with-node-windows-amd64.zip': '749d8e09fd5d23fc8af12892b7d197add5aae004f7438678023e4a973f3fd58b',
+  },
+};
+
+// Digests of the extracted ckb-tui binaries, keyed the same way as
+// KNOWN_SHA256. ensureInstalled uses these to recognize a stale or foreign
+// binary at the install path: ckb-tui's own `--version` output lags its
+// release tag (the v0.1.4 binary still reports 0.1.2), so the on-disk digest
+// is the only reliable identity. Versions without a pinned binary digest fall
+// back to presence-only detection (install-time archive verification still
+// applies).
+const KNOWN_BINARY_SHA256: Record<string, Record<string, string>> = {
+  'v0.1.4': {
+    'ckb-tui-with-node-linux-amd64.tar.gz': 'e2c31db99e81ea6ae0455796464a671c10bf8fe74615c40b995c34ff57630b43',
+    'ckb-tui-with-node-macos-aarch64.tar.gz': 'a9748cf1581568cf7409193d5cb851ea956a82a84fd69c08513fee351a8ad7fc',
+    'ckb-tui-with-node-windows-amd64.zip': '2ed73cd9095b2f9b947377736e8013985f48a8c1e696a3dd78033af658aab612',
+  },
+  'v0.1.3': {
+    'ckb-tui-with-node-linux-amd64.tar.gz': '2daca14ea8eba2a7888d1223c387a8d8e0846dafc424cd66891d4d96f4720005',
+    'ckb-tui-with-node-macos-aarch64.tar.gz': 'e21971d59edce7d5d590ac05314d67343fb70187a73a8dd19af87a71e1fe34e0',
+    'ckb-tui-with-node-windows-amd64.zip': 'b2fce1c161158e8a2dd5b5c5a796091f3c668e57e57b8dd403053ceef1301716',
   },
 };
 
@@ -44,12 +69,17 @@ export class CKBTui {
 
   /**
    * Returns the binary path, downloading and installing if the binary
-   * does not already exist.
+   * does not already exist or does not match the configured version's
+   * pinned digest (e.g. a stale binary from an older default release).
    */
   static ensureInstalled(): string {
     const binaryPath = this.getBinaryPath();
     if (binaryPath && fs.existsSync(binaryPath)) {
-      return binaryPath;
+      if (this.installedBinaryMatches(binaryPath)) {
+        return binaryPath;
+      }
+      logger.info('The installed ckb-tui does not match the configured release; reinstalling...');
+      fs.rmSync(binaryPath, { force: true });
     }
 
     // Reset and re-install
@@ -75,6 +105,22 @@ export class CKBTui {
   // --- private helpers ---
 
   /**
+   * Verifies an existing on-disk binary against the configured version's
+   * pinned binary digest. Returns true when the binary may be kept: either it
+   * matches the digest, or the configured version has no pinned binary digest
+   * (presence-only fallback; install-time archive verification still applies).
+   */
+  private static installedBinaryMatches(binaryPath: string): boolean {
+    const settings = readSettings();
+    const expected = KNOWN_BINARY_SHA256[settings.tools.ckbTui.version]?.[this.getAssetName()];
+    if (!expected) {
+      return true;
+    }
+    const actual = crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
+    return actual === expected;
+  }
+
+  /**
    * Resolve and validate that the configured rootFolder is under the
    * OffCKB data directory. Rejects paths that resolve outside.
    */
@@ -96,7 +142,7 @@ export class CKBTui {
 
   private static validateVersion(version: string): void {
     if (!STRICT_VERSION_REGEX.test(version)) {
-      throw new Error(`Invalid version format: "${version}". Expected format: vX.Y.Z (e.g., v0.1.3)`);
+      throw new Error(`Invalid version format: "${version}". Expected format: vX.Y.Z (e.g., v0.1.4)`);
     }
   }
 

--- a/src/tools/ckb-tui.ts
+++ b/src/tools/ckb-tui.ts
@@ -340,7 +340,9 @@ export class CKBTui {
       try {
         fs.copyFileSync(source, stagingPath);
         fs.renameSync(stagingPath, target);
-        fs.unlinkSync(source);
+        // No cleanup of `source` here: it lives in the temp directory, which
+        // the caller removes regardless of outcome — don't let a cleanup
+        // error turn the successful publish above into a reported failure.
       } finally {
         fs.rmSync(stagingPath, { force: true });
       }

--- a/src/tools/ckb-tui.ts
+++ b/src/tools/ckb-tui.ts
@@ -74,15 +74,17 @@ export class CKBTui {
    */
   static ensureInstalled(): string {
     const binaryPath = this.getBinaryPath();
+    if (binaryPath && this.installedBinaryMatches(binaryPath)) {
+      return binaryPath;
+    }
     if (binaryPath && fs.existsSync(binaryPath)) {
-      if (this.installedBinaryMatches(binaryPath)) {
-        return binaryPath;
-      }
       logger.info('The installed ckb-tui does not match the configured release; reinstalling...');
-      fs.rmSync(binaryPath, { force: true });
     }
 
-    // Reset and re-install
+    // Re-install. The existing binary is deliberately left in place: installSync
+    // downloads, verifies, and extracts into a temp directory and only then
+    // publishes with an atomic rename, so a failed reinstall keeps the previous
+    // binary instead of stranding the user with none.
     this.binaryPath = null;
     this.installSync();
     return this.binaryPath!;
@@ -109,15 +111,21 @@ export class CKBTui {
    * pinned binary digest. Returns true when the binary may be kept: either it
    * matches the digest, or the configured version has no pinned binary digest
    * (presence-only fallback; install-time archive verification still applies).
+   * Missing, unreadable, or non-regular paths (e.g. a directory) count as a
+   * mismatch so the reinstall flow runs instead of crashing with a raw fs error.
    */
   private static installedBinaryMatches(binaryPath: string): boolean {
     const settings = readSettings();
     const expected = KNOWN_BINARY_SHA256[settings.tools.ckbTui.version]?.[this.getAssetName()];
-    if (!expected) {
-      return true;
+    try {
+      if (!expected) {
+        return fs.statSync(binaryPath).isFile();
+      }
+      const actual = crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
+      return actual === expected;
+    } catch {
+      return false;
     }
-    const actual = crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
-    return actual === expected;
   }
 
   /**

--- a/src/tools/ckb-tui.ts
+++ b/src/tools/ckb-tui.ts
@@ -111,15 +111,24 @@ export class CKBTui {
    * pinned binary digest. Returns true when the binary may be kept: either it
    * matches the digest, or the configured version has no pinned binary digest
    * (presence-only fallback; install-time archive verification still applies).
-   * Missing, unreadable, or non-regular paths (e.g. a directory) count as a
-   * mismatch so the reinstall flow runs instead of crashing with a raw fs error.
+   * Missing, unreadable, or non-regular paths (e.g. a directory or FIFO) count
+   * as a mismatch so the reinstall flow runs instead of crashing with a raw fs
+   * error, blocking forever on a special file, or failing later at spawn time.
    */
   private static installedBinaryMatches(binaryPath: string): boolean {
     const settings = readSettings();
     const expected = KNOWN_BINARY_SHA256[settings.tools.ckbTui.version]?.[this.getAssetName()];
     try {
+      // Require a regular file first: opening a FIFO or device for reading
+      // would block indefinitely, before any digest comparison could run.
+      if (!fs.statSync(binaryPath).isFile()) {
+        return false;
+      }
+      // Metadata alone does not prove readability; an unreadable binary must
+      // flow into the reinstall path (which republishes with correct modes).
+      fs.accessSync(binaryPath, fs.constants.R_OK);
       if (!expected) {
-        return fs.statSync(binaryPath).isFile();
+        return true;
       }
       const actual = crypto.createHash('sha256').update(fs.readFileSync(binaryPath)).digest('hex');
       return actual === expected;
@@ -238,27 +247,11 @@ export class CKBTui {
         throw new Error(`ckb-tui binary ("${binaryName}") was not found after extraction.`);
       }
 
-      // 5. Move to the final location. renameSync is atomic but throws EXDEV
-      // when the temp dir and the data path live on different filesystems
-      // (common in containers). In that case stage the copy inside binDir and
-      // publish it with a rename, so a concurrent ensureInstalled() never sees
-      // a partially copied binary at the final path.
-      try {
-        fs.renameSync(extractedBinary, this.binaryPath);
-      } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === 'EXDEV') {
-          const stagingPath = path.join(binDir, `.${binaryName}.staging-${process.pid}`);
-          try {
-            fs.copyFileSync(extractedBinary, stagingPath);
-            fs.renameSync(stagingPath, this.binaryPath);
-            fs.unlinkSync(extractedBinary);
-          } finally {
-            fs.rmSync(stagingPath, { force: true });
-          }
-        } else {
-          throw error;
-        }
-      }
+      // 5. Publish the verified binary. publishExtractedBinary owns the edge
+      // cases: a directory occupying the install path is set aside (and
+      // restored on failure), and cross-filesystem temp dirs fall back to a
+      // staged copy next to the target.
+      this.publishExtractedBinary(extractedBinary, this.binaryPath);
 
       // 6. Make executable on Unix
       if (process.platform !== 'win32') {
@@ -284,6 +277,72 @@ export class CKBTui {
         fs.rmSync(tempDir, { recursive: true, force: true });
       } catch {
         // Best-effort cleanup — temp dir will be cleaned by the OS eventually
+      }
+    }
+  }
+
+  /**
+   * Atomically publish the extracted binary to the install path.
+   *
+   * A directory occupying the install path (e.g. from a botched manual
+   * extraction) cannot be replaced by a file rename — without this handling
+   * the reinstall would fail on every attempt — so it is first set aside with
+   * a plain rename (its contents are never deleted) and restored if publishing
+   * fails. On success the aside directory is left in place and its location
+   * logged, so nothing the user put there is silently destroyed.
+   */
+  private static publishExtractedBinary(extractedBinary: string, binaryPath: string): void {
+    let dirBackupPath: string | null = null;
+    let existing: fs.Stats | null = null;
+    try {
+      existing = fs.lstatSync(binaryPath);
+    } catch {
+      existing = null; // Nothing at the install path.
+    }
+    if (existing?.isDirectory()) {
+      dirBackupPath = `${binaryPath}.backup-${process.pid}-${Date.now()}`;
+      fs.renameSync(binaryPath, dirBackupPath);
+    }
+
+    try {
+      this.renameIntoPlace(extractedBinary, binaryPath);
+    } catch (error) {
+      if (dirBackupPath) {
+        try {
+          fs.renameSync(dirBackupPath, binaryPath);
+        } catch {
+          // Best effort: the original directory remains at its backup path.
+        }
+      }
+      throw error;
+    }
+
+    if (dirBackupPath) {
+      logger.info(`A directory unexpectedly occupied ${binaryPath}; moved it aside to ${dirBackupPath}.`);
+    }
+  }
+
+  /**
+   * renameSync is atomic but throws EXDEV when source and target live on
+   * different filesystems (common in containers, where os.tmpdir() and the
+   * data path differ). In that case stage the copy next to the target and
+   * publish it with a rename, so a concurrent ensureInstalled() never sees a
+   * partially copied binary at the final path.
+   */
+  private static renameIntoPlace(source: string, target: string): void {
+    try {
+      fs.renameSync(source, target);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EXDEV') {
+        throw error;
+      }
+      const stagingPath = path.join(path.dirname(target), `.${path.basename(target)}.staging-${process.pid}`);
+      try {
+        fs.copyFileSync(source, stagingPath);
+        fs.renameSync(stagingPath, target);
+        fs.unlinkSync(source);
+      } finally {
+        fs.rmSync(stagingPath, { force: true });
       }
     }
   }

--- a/tests/ckb-tui-checksum.test.ts
+++ b/tests/ckb-tui-checksum.test.ts
@@ -30,7 +30,7 @@ describe('ckb-tui checksum policy', () => {
   it('enforces the pinned digest for the default release without a network fallback', () => {
     expect(() =>
       (CKBTui as unknown as { verifyChecksum: (...args: string[]) => void }).verifyChecksum(
-        'v0.1.3',
+        'v0.1.4',
         'ckb-tui-with-node-macos-aarch64.tar.gz',
         archive,
       ),

--- a/tests/ckb-tui-install.test.ts
+++ b/tests/ckb-tui-install.test.ts
@@ -46,7 +46,11 @@ describe('ckb-tui installed-binary verification', () => {
     mockVersion.current = 'v0.1.4';
     internals.binaryPath = null;
     realInstallSync = internals.installSync;
-    installSpy = jest.fn();
+    // Mimic a successful installSync: publish the binary path. Tests that need
+    // a failing install override this with mockImplementation.
+    installSpy = jest.fn().mockImplementation(() => {
+      internals.binaryPath = binaryPath;
+    });
     internals.installSync = installSpy;
   });
 
@@ -87,11 +91,31 @@ describe('ckb-tui installed-binary verification', () => {
   it('reinstalls when the on-disk binary does not match the pinned digest', () => {
     fs.writeFileSync(binaryPath, 'stale ckb-tui from an older release');
 
-    expect(() => CKBTui.ensureInstalled()).not.toThrow();
+    expect(CKBTui.ensureInstalled()).toBe(binaryPath);
     expect(installSpy).toHaveBeenCalledTimes(1);
-    // The stale binary must be removed before install so no platform-specific
-    // rename-over-existing behavior can keep it in place.
-    expect(fs.existsSync(binaryPath)).toBe(false);
+    // The stale binary is NOT deleted up front: it stays in place until
+    // installSync atomically publishes the verified replacement, so a failed
+    // reinstall never strands the user with no binary. (The spy skips the real
+    // replacement, so the original file is still there.)
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe('stale ckb-tui from an older release');
+  });
+
+  it('keeps the existing binary when the reinstall fails', () => {
+    fs.writeFileSync(binaryPath, 'stale ckb-tui from an older release');
+    installSpy.mockImplementation(() => {
+      internals.binaryPath = null;
+      throw new Error('network down');
+    });
+
+    expect(() => CKBTui.ensureInstalled()).toThrow('network down');
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe('stale ckb-tui from an older release');
+  });
+
+  it('treats a non-regular path at the binary location as a mismatch and reinstalls', () => {
+    fs.mkdirSync(binaryPath);
+
+    expect(CKBTui.ensureInstalled()).toBe(binaryPath);
+    expect(installSpy).toHaveBeenCalledTimes(1);
   });
 
   it('falls back to presence-only detection for a release without a pinned binary digest', () => {
@@ -103,7 +127,7 @@ describe('ckb-tui installed-binary verification', () => {
   });
 
   it('installs when no binary exists yet', () => {
-    CKBTui.ensureInstalled();
+    expect(CKBTui.ensureInstalled()).toBe(binaryPath);
     expect(installSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/ckb-tui-install.test.ts
+++ b/tests/ckb-tui-install.test.ts
@@ -1,0 +1,109 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import crypto from 'crypto';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawnSync: jest.fn(),
+}));
+jest.mock('../src/util/logger', () => ({
+  logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
+}));
+
+const mockVersion = { current: 'v0.1.4' };
+const mockDirs = { dataRoot: '', toolsRoot: '' };
+
+jest.mock('../src/cfg/setting', () => ({
+  get dataPath() {
+    return mockDirs.dataRoot;
+  },
+  readSettings: () => ({
+    tools: { rootFolder: mockDirs.toolsRoot, ckbTui: { version: mockVersion.current } },
+  }),
+}));
+
+import { CKBTui } from '../src/tools/ckb-tui';
+
+type CKBTuiInternals = {
+  binaryPath: string | null;
+  installSync: () => void;
+  installedBinaryMatches: (binaryPath: string) => boolean;
+};
+
+describe('ckb-tui installed-binary verification', () => {
+  const internals = CKBTui as unknown as CKBTuiInternals;
+  let realInstallSync: () => void;
+  let installSpy: jest.Mock;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDirs.dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-tui-data-'));
+    mockDirs.toolsRoot = path.join(mockDirs.dataRoot, 'tools');
+    fs.mkdirSync(mockDirs.toolsRoot, { recursive: true });
+    binaryPath = path.join(mockDirs.toolsRoot, process.platform === 'win32' ? 'ckb-tui.exe' : 'ckb-tui');
+    mockVersion.current = 'v0.1.4';
+    internals.binaryPath = null;
+    realInstallSync = internals.installSync;
+    installSpy = jest.fn();
+    internals.installSync = installSpy;
+  });
+
+  afterEach(() => {
+    internals.installSync = realInstallSync;
+    internals.binaryPath = null;
+    fs.rmSync(mockDirs.dataRoot, { recursive: true, force: true });
+    jest.restoreAllMocks();
+  });
+
+  const assetName = () => {
+    if (process.platform === 'darwin') return 'ckb-tui-with-node-macos-aarch64.tar.gz';
+    if (process.platform === 'win32') return 'ckb-tui-with-node-windows-amd64.zip';
+    return 'ckb-tui-with-node-linux-amd64.tar.gz';
+  };
+
+  // The pinned binary digest for the current platform's v0.1.4 asset, kept in
+  // sync with KNOWN_BINARY_SHA256 in src/tools/ckb-tui.ts.
+  const pinnedDigest = () =>
+    (
+      ({
+        'ckb-tui-with-node-linux-amd64.tar.gz': 'e2c31db99e81ea6ae0455796464a671c10bf8fe74615c40b995c34ff57630b43',
+        'ckb-tui-with-node-macos-aarch64.tar.gz': 'a9748cf1581568cf7409193d5cb851ea956a82a84fd69c08513fee351a8ad7fc',
+        'ckb-tui-with-node-windows-amd64.zip': '2ed73cd9095b2f9b947377736e8013985f48a8c1e696a3dd78033af658aab612',
+      }) as Record<string, string>
+    )[assetName()];
+
+  it('keeps an existing binary whose digest matches the configured release', () => {
+    fs.writeFileSync(binaryPath, 'installed ckb-tui');
+    jest.spyOn(crypto, 'createHash').mockReturnValue({
+      update: () => ({ digest: () => pinnedDigest() }),
+    } as unknown as crypto.Hash);
+
+    expect(CKBTui.ensureInstalled()).toBe(binaryPath);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  it('reinstalls when the on-disk binary does not match the pinned digest', () => {
+    fs.writeFileSync(binaryPath, 'stale ckb-tui from an older release');
+
+    expect(() => CKBTui.ensureInstalled()).not.toThrow();
+    expect(installSpy).toHaveBeenCalledTimes(1);
+    // The stale binary must be removed before install so no platform-specific
+    // rename-over-existing behavior can keep it in place.
+    expect(fs.existsSync(binaryPath)).toBe(false);
+  });
+
+  it('falls back to presence-only detection for a release without a pinned binary digest', () => {
+    mockVersion.current = 'v9.9.9';
+    fs.writeFileSync(binaryPath, 'any content at all');
+
+    expect(CKBTui.ensureInstalled()).toBe(binaryPath);
+    expect(installSpy).not.toHaveBeenCalled();
+  });
+
+  it('installs when no binary exists yet', () => {
+    CKBTui.ensureInstalled();
+    expect(installSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/ckb-tui-install.test.ts
+++ b/tests/ckb-tui-install.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import crypto from 'crypto';
+import { execFileSync } from 'child_process';
 
 jest.mock('child_process', () => ({
   ...jest.requireActual('child_process'),
@@ -29,7 +30,14 @@ type CKBTuiInternals = {
   binaryPath: string | null;
   installSync: () => void;
   installedBinaryMatches: (binaryPath: string) => boolean;
+  publishExtractedBinary: (extractedBinary: string, binaryPath: string) => void;
 };
+
+const binaryName = () => (process.platform === 'win32' ? 'ckb-tui.exe' : 'ckb-tui');
+
+// Content the successful install spy publishes, standing in for the verified
+// binary the real installSync would atomically rename into place.
+const REPLACED_BINARY = 'verified replacement ckb-tui';
 
 describe('ckb-tui installed-binary verification', () => {
   const internals = CKBTui as unknown as CKBTuiInternals;
@@ -42,13 +50,23 @@ describe('ckb-tui installed-binary verification', () => {
     mockDirs.dataRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-tui-data-'));
     mockDirs.toolsRoot = path.join(mockDirs.dataRoot, 'tools');
     fs.mkdirSync(mockDirs.toolsRoot, { recursive: true });
-    binaryPath = path.join(mockDirs.toolsRoot, process.platform === 'win32' ? 'ckb-tui.exe' : 'ckb-tui');
+    binaryPath = path.join(mockDirs.toolsRoot, binaryName());
     mockVersion.current = 'v0.1.4';
     internals.binaryPath = null;
     realInstallSync = internals.installSync;
-    // Mimic a successful installSync: publish the binary path. Tests that need
-    // a failing install override this with mockImplementation.
+    // Mimic a successful installSync: publish a real regular replacement file
+    // at the install path (setting aside a directory that occupies it, like
+    // the real publish step does). Tests that need a failing install override
+    // this with a no-publish mockImplementation that throws.
     installSpy = jest.fn().mockImplementation(() => {
+      try {
+        if (fs.lstatSync(binaryPath).isDirectory()) {
+          fs.renameSync(binaryPath, `${binaryPath}.set-aside`);
+        }
+      } catch {
+        // Nothing at the install path yet.
+      }
+      fs.writeFileSync(binaryPath, REPLACED_BINARY);
       internals.binaryPath = binaryPath;
     });
     internals.installSync = installSpy;
@@ -90,14 +108,19 @@ describe('ckb-tui installed-binary verification', () => {
 
   it('reinstalls when the on-disk binary does not match the pinned digest', () => {
     fs.writeFileSync(binaryPath, 'stale ckb-tui from an older release');
+    installSpy.mockImplementation(() => {
+      // The stale binary is NOT deleted up front: it is still in place when
+      // the reinstall begins and is only replaced once the verified new
+      // binary is ready to publish.
+      expect(fs.readFileSync(binaryPath, 'utf8')).toBe('stale ckb-tui from an older release');
+      fs.writeFileSync(binaryPath, REPLACED_BINARY);
+      internals.binaryPath = binaryPath;
+    });
 
     expect(CKBTui.ensureInstalled()).toBe(binaryPath);
     expect(installSpy).toHaveBeenCalledTimes(1);
-    // The stale binary is NOT deleted up front: it stays in place until
-    // installSync atomically publishes the verified replacement, so a failed
-    // reinstall never strands the user with no binary. (The spy skips the real
-    // replacement, so the original file is still there.)
-    expect(fs.readFileSync(binaryPath, 'utf8')).toBe('stale ckb-tui from an older release');
+    expect(fs.statSync(binaryPath).isFile()).toBe(true);
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(REPLACED_BINARY);
   });
 
   it('keeps the existing binary when the reinstall fails', () => {
@@ -116,6 +139,8 @@ describe('ckb-tui installed-binary verification', () => {
 
     expect(CKBTui.ensureInstalled()).toBe(binaryPath);
     expect(installSpy).toHaveBeenCalledTimes(1);
+    expect(fs.statSync(binaryPath).isFile()).toBe(true);
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(REPLACED_BINARY);
   });
 
   it('falls back to presence-only detection for a release without a pinned binary digest', () => {
@@ -129,5 +154,80 @@ describe('ckb-tui installed-binary verification', () => {
   it('installs when no binary exists yet', () => {
     expect(CKBTui.ensureInstalled()).toBe(binaryPath);
     expect(installSpy).toHaveBeenCalledTimes(1);
+    expect(fs.statSync(binaryPath).isFile()).toBe(true);
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(REPLACED_BINARY);
+  });
+
+  const itPosix = process.platform === 'win32' ? it.skip : it;
+  const itPosixNonRoot = process.platform === 'win32' || (process.getuid && process.getuid() === 0) ? it.skip : it;
+
+  itPosix('does not block on a FIFO at the binary location', () => {
+    // Pinned digest path: the digest read must not open a FIFO, whose
+    // blocking read would hang ensureInstalled indefinitely. (Regression
+    // guard: without the regular-file check this test times out.)
+    execFileSync('mkfifo', [binaryPath]);
+
+    expect(internals.installedBinaryMatches(binaryPath)).toBe(false);
+  });
+
+  itPosixNonRoot('treats an unreadable binary as a mismatch', () => {
+    mockVersion.current = 'v9.9.9'; // Unpinned: presence alone must not suffice.
+    fs.writeFileSync(binaryPath, 'unreadable ckb-tui', { mode: 0o000 });
+
+    expect(internals.installedBinaryMatches(binaryPath)).toBe(false);
+  });
+});
+
+describe('ckb-tui binary publishing', () => {
+  const internals = CKBTui as unknown as CKBTuiInternals;
+  let binDir: string;
+  let binaryPath: string;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-tui-publish-'));
+    binaryPath = path.join(binDir, binaryName());
+  });
+
+  afterEach(() => fs.rmSync(binDir, { recursive: true, force: true }));
+
+  it('replaces an existing file in place', () => {
+    fs.writeFileSync(binaryPath, 'old binary');
+    const extracted = path.join(binDir, 'extracted-ckb-tui');
+    fs.writeFileSync(extracted, REPLACED_BINARY);
+
+    internals.publishExtractedBinary(extracted, binaryPath);
+
+    expect(fs.statSync(binaryPath).isFile()).toBe(true);
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(REPLACED_BINARY);
+  });
+
+  it('replaces a directory occupying the install path without deleting its contents', () => {
+    fs.mkdirSync(binaryPath);
+    fs.writeFileSync(path.join(binaryPath, 'user-file.txt'), 'user data');
+    const extracted = path.join(binDir, 'extracted-ckb-tui');
+    fs.writeFileSync(extracted, REPLACED_BINARY);
+
+    internals.publishExtractedBinary(extracted, binaryPath);
+
+    expect(fs.statSync(binaryPath).isFile()).toBe(true);
+    expect(fs.readFileSync(binaryPath, 'utf8')).toBe(REPLACED_BINARY);
+    // The directory was set aside with a plain rename, not deleted.
+    const backups = fs.readdirSync(binDir).filter((name) => name.startsWith(`${binaryName()}.backup-`));
+    expect(backups).toHaveLength(1);
+    expect(fs.readFileSync(path.join(binDir, backups[0], 'user-file.txt'), 'utf8')).toBe('user data');
+  });
+
+  it('restores the original directory when publishing fails', () => {
+    fs.mkdirSync(binaryPath);
+    fs.writeFileSync(path.join(binaryPath, 'user-file.txt'), 'user data');
+
+    expect(() => internals.publishExtractedBinary(path.join(binDir, 'missing-binary'), binaryPath)).toThrow();
+
+    expect(fs.statSync(binaryPath).isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(binaryPath, 'user-file.txt'), 'utf8')).toBe('user data');
+    // No set-aside backup is left behind after the successful restore.
+    const backups = fs.readdirSync(binDir).filter((name) => name.startsWith(`${binaryName()}.backup-`));
+    expect(backups).toHaveLength(0);
   });
 });

--- a/tests/ckb-tui-install.test.ts
+++ b/tests/ckb-tui-install.test.ts
@@ -163,11 +163,16 @@ describe('ckb-tui installed-binary verification', () => {
 
   itPosix('does not block on a FIFO at the binary location', () => {
     // Pinned digest path: the digest read must not open a FIFO, whose
-    // blocking read would hang ensureInstalled indefinitely. (Regression
-    // guard: without the regular-file check this test times out.)
+    // blocking read would hang ensureInstalled indefinitely. readFileSync is
+    // mocked to throw so a regression fails fast instead of hanging the Jest
+    // worker synchronously (a timer-based timeout cannot fire mid-read).
     execFileSync('mkfifo', [binaryPath]);
+    const readFileSync = jest.spyOn(fs, 'readFileSync').mockImplementation(() => {
+      throw new Error('A FIFO must not be read');
+    });
 
     expect(internals.installedBinaryMatches(binaryPath)).toBe(false);
+    expect(readFileSync).not.toHaveBeenCalled();
   });
 
   itPosixNonRoot('treats an unreadable binary as a mismatch', () => {


### PR DESCRIPTION
## What

ckb-tui [v0.1.4](https://github.com/Officeyutong/ckb-tui/releases/tag/v0.1.4) fixes a divide-by-zero panic in the dashboard data-sync thread when the connected node has no peers ([Officeyutong/ckb-tui#13](https://github.com/Officeyutong/ckb-tui/pull/13)). A single-node devnet always has zero peers, so `offckb status --network devnet` hit this within seconds of opening: the sync thread died and the Overview, Mempool, Peers, and Blockchain panels froze/emptied permanently.

This PR bumps the bundled default to v0.1.4 and makes sure existing installs actually pick it up:

- **`src/cfg/setting.ts`** — default `tools.ckbTui.version` `v0.1.3` → `v0.1.4`.
- **`src/tools/ckb-tui.ts`** —
  - Pin SHA-256 digests of the three v0.1.4 release archives (computed locally from the release assets; the v0.1.3 pins are kept so a pinned older version still installs).
  - **New:** pin digests of the *extracted* binaries and verify the installed binary against them in `ensureInstalled()`. This is needed because ckb-tui's `--version` output lags its release tag — both the v0.1.3 and v0.1.4 binaries report `ckb-tui 0.1.2` — so a presence-only check would keep the panic-affected v0.1.3 binary installed forever and users would never receive the fix. A stale/foreign binary is now removed and reinstalled; configured versions without a pinned binary digest keep the previous presence-only behavior (install-time archive verification still applies).
- **`tests/ckb-tui-checksum.test.ts`** — point the pinned-digest test at v0.1.4.
- **`tests/ckb-tui-install.test.ts`** (new) — covers keep-when-matching, reinstall-when-stale (including removing the old binary first), presence-only fallback for unpinned versions, and fresh install.
- Changeset included (patch).

## Verification

- `pnpm lint` (0 errors), `pnpm build`, and the full `pnpm test` suite (29 suites, 224 passed) are green.
- End-to-end on Linux: planted the real v0.1.3 binary at the install path, ran `ensureInstalled()` — it detected the digest mismatch, re-downloaded v0.1.4, verified the archive checksum, and installed it; the final on-disk binary hashes to the pinned v0.1.4 digest and runs. A second invocation is a no-op (no re-download).
- The v0.1.3 asset digests re-computed during this work match the existing pins, cross-checking the download pipeline.