### PR TITLE
fix(node): adapt devnet Terminal RPC module to the CKB version

### DIFF
--- a/.changeset/terminal-rpc-version-compat.md
+++ b/.changeset/terminal-rpc-version-compat.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Fix devnet startup crashing for CKB binaries older than v0.205.0. The devnet ckb.toml template enables the `Terminal` RPC module, which only exists since CKB v0.205.0; older binaries abort at startup with an opaque serde "unknown variant" error, and the legacy-config migration re-added the module on every `offckb node` start even after users removed it by hand. offckb now adapts the devnet config to the CKB version: fresh chains for an old binary are initialized without `Terminal` (the migration also stops re-adding it, while still enabling `tcp_listen_address`), a config that already has `Terminal` paired with an old binary fails fast with an actionable error instead of the serde dump, and an unprobeable custom `--binary-path` that crashes with the tell-tale "unknown variant `Terminal`" message now gets a hint pointing at the cause. The `offckb status` system-metric panels require CKB >= 0.205.0; the README's `status` section says so.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ offckb status --network mainnet
 
 `status` performs a JSON-RPC health check through the proxy before opening the TUI and requires an interactive terminal.
 
+The TUI's system-metric panels are powered by CKB's `Terminal` RPC module, which requires CKB >= 0.205.0. If you run the devnet with an older CKB (e.g. `offckb node 0.120.0` or `--binary-path` pointing at an old build), offckb starts the node without that module and those panels will be unavailable; upgrade CKB to get them.
+
 ### 2. Create a New Contract Project {#create-project}
 
 Generate a ready-to-use smart-contract project in JS/TS using templates:

--- a/src/cmd/node.ts
+++ b/src/cmd/node.ts
@@ -1,8 +1,13 @@
 import { execFile, execFileSync, spawn, ChildProcess } from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import { initChainIfNeeded } from '../node/init-chain';
-import { installCKBBinary } from '../node/install';
+import {
+  initChainIfNeeded,
+  devnetConfigHasTerminalRpc,
+  supportsTerminalRpcModule,
+  TERMINAL_RPC_MIN_CKB_VERSION,
+} from '../node/init-chain';
+import { getVersionFromBinary, installCKBBinary } from '../node/install';
 import { getCKBBinaryPath, readSettings } from '../cfg/setting';
 import { createRPCProxy } from '../tools/rpc-proxy';
 import { markForkFirstRunComplete, readForkState } from '../devnet/fork';
@@ -66,16 +71,41 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   const settings = readSettings();
   const ckbVersion = version || settings.bins.defaultCKBVersion;
   let ckbBinPath = '';
+  // The version the chain config will be validated against. A managed binary
+  // knows its version by construction; a custom --binary-path is probed, and
+  // an unprobeable binary stays null (unknown → assume Terminal-capable).
+  let effectiveCkbVersion: string | null = null;
 
   if (binaryPath) {
     ckbBinPath = binaryPath;
     logger.info(`Using custom CKB binary path: ${ckbBinPath}`);
+    effectiveCkbVersion = getVersionFromBinary(ckbBinPath);
   } else {
     await installCKBBinary(ckbVersion);
     ckbBinPath = getCKBBinaryPath(ckbVersion);
+    effectiveCkbVersion = ckbVersion;
   }
-  await initChainIfNeeded();
+  await initChainIfNeeded({ ckbVersion: effectiveCkbVersion });
   const devnetConfigPath = settings.devnet.configPath;
+
+  // A config that enables the Terminal RPC module crashes CKB < 0.205.0 at
+  // startup with an opaque serde error ("unknown variant `Terminal`"). Catch
+  // that combination before spawning and say what is actually wrong. The
+  // version-aware init above never *adds* Terminal for such a binary, so
+  // hitting this means the config genuinely predates/downgraded past us.
+  if (!supportsTerminalRpcModule(effectiveCkbVersion) && devnetConfigHasTerminalRpc(devnetConfigPath)) {
+    throw new Error(
+      `The devnet config (${path.join(devnetConfigPath, 'ckb.toml')}) enables the "Terminal" RPC module, ` +
+        `which requires CKB >= ${TERMINAL_RPC_MIN_CKB_VERSION}; the selected binary is ${effectiveCkbVersion}. ` +
+        `Upgrade the CKB version or remove "Terminal" from rpc.modules in that file.`,
+    );
+  }
+  if (!supportsTerminalRpcModule(effectiveCkbVersion)) {
+    logger.info(
+      `CKB ${effectiveCkbVersion} predates the Terminal RPC module; ` +
+        `the system-metric panels of \`offckb status\` require CKB >= ${TERMINAL_RPC_MIN_CKB_VERSION}.`,
+    );
+  }
 
   // A forked devnet must boot once with --skip-spec-check --overwrite-spec so
   // the imported (and patched) spec replaces the source chain's stored spec.
@@ -90,7 +120,14 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   if (firstRunFlags) runArgs.push('--skip-spec-check', '--overwrite-spec');
   const ckbProcess = spawn(ckbBinPath, runArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
   ckbProcess.stdout?.on('data', (data) => logger.info(['CKB:', cleanChildOutput(data)]));
-  ckbProcess.stderr?.on('data', (data) => logger.error(['CKB error:', cleanChildOutput(data)]));
+  // Keep a bounded stderr tail so a startup crash can be translated into an
+  // actionable error below (CKB's own config errors are notoriously opaque).
+  let ckbStderrTail = '';
+  ckbProcess.stderr?.on('data', (data) => {
+    const text = cleanChildOutput(data);
+    ckbStderrTail = (ckbStderrTail + text).slice(-4096);
+    logger.error(['CKB error:', text]);
+  });
 
   let ckbExited = false;
   ckbProcess.once('exit', () => {
@@ -104,7 +141,8 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   const readiness = await waitForNodeReady(settings.devnet.rpcUrl, timeoutMs, () => !ckbExited);
   if (!readiness.ready) {
     if (!ckbExited) ckbProcess.kill('SIGTERM');
-    throw new Error(`CKB devnet failed to become ready: ${readiness.error ?? 'CKB process exited'}`);
+    const hint = terminalRpcUnknownVariantHint(ckbStderrTail, devnetConfigPath);
+    throw new Error(`CKB devnet failed to become ready: ${readiness.error ?? 'CKB process exited'}${hint ?? ''}`);
   }
   if (ckbExited) {
     throw new Error('CKB devnet exited immediately after its readiness check.');
@@ -165,6 +203,19 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   };
   ckbProcess.once('exit', (code, signal) => stopService('CKB node', code, signal));
   minerProcess.once('exit', (code, signal) => stopService('CKB miner', code, signal));
+}
+
+// CKB < 0.205.0 rejects the Terminal RPC module during config deserialization
+// with a serde "unknown variant `Terminal`" error and exits. When startup
+// fails with that signature — the realistic case being a custom --binary-path
+// whose version could not be probed — point at the actual cause instead of
+// leaving the user with the raw serde message.
+export function terminalRpcUnknownVariantHint(stderrTail: string, devnetConfigPath: string): string | null {
+  if (!/unknown variant [`'"]?Terminal/.test(stderrTail)) return null;
+  return (
+    ` The "Terminal" RPC module requires CKB >= ${TERMINAL_RPC_MIN_CKB_VERSION}; ` +
+    `remove "Terminal" from rpc.modules in ${path.join(devnetConfigPath, 'ckb.toml')} or use a newer CKB binary.`
+  );
 }
 
 function waitForChildSpawn(child: ChildProcess, label: string): Promise<void> {

--- a/src/node/init-chain.ts
+++ b/src/node/init-chain.ts
@@ -1,14 +1,24 @@
 import fs from 'fs';
 import path from 'path';
+import semver from 'semver';
 import toml, { JsonMap } from '@iarna/toml';
 import { isFolderExists, copyFilesWithExclusion } from '../util/fs';
 import { packageRootPath, readSettings } from '../cfg/setting';
 import { logger } from '../util/logger';
 
-export async function initChainIfNeeded() {
+export interface InitChainOptions {
+  // Version of the CKB binary the chain is being initialized for, when known.
+  // Drives whether the Terminal RPC module (CKB >= 0.205.0) may appear in the
+  // resulting ckb.toml. Null/undefined means "unknown" and keeps the
+  // historical behavior of assuming support.
+  ckbVersion?: string | null;
+}
+
+export async function initChainIfNeeded(options: InitChainOptions = {}) {
   const settings = readSettings();
   const devnetSourcePath = path.resolve(packageRootPath, './ckb/devnet');
   const devnetConfigPath = settings.devnet.configPath;
+  const ckbTomlPath = path.join(devnetConfigPath, 'ckb.toml');
   const requiredConfigFiles = ['ckb.toml', 'ckb-miner.toml', path.join('specs', 'dev.toml')];
   const isInitialized =
     isFolderExists(devnetConfigPath) &&
@@ -20,6 +30,10 @@ export async function initChainIfNeeded() {
   // check therefore mistakes a fresh install for an initialized chain. Check
   // the files CKB actually needs instead, and repair an incomplete directory.
   if (!isInitialized) {
+    // Whether the ckb.toml about to be written is the pristine bundled
+    // template (as opposed to a pre-existing user file being repaired around).
+    // Only a pristine template may be adapted to the CKB version below.
+    const ckbTomlWasMissing = !fs.existsSync(ckbTomlPath);
     await copyFilesWithExclusion(devnetSourcePath, devnetConfigPath, ['data'], false);
     logger.debug(`init devnet config folder: ${devnetConfigPath}`);
 
@@ -33,13 +47,52 @@ export async function initChainIfNeeded() {
       // Write the modified content back to the file
       fs.writeFileSync(minerConfigPath, modifiedData, 'utf8');
     }
+
+    // The bundled template enables the Terminal RPC module, which CKB
+    // versions before 0.205.0 reject at startup (serde "unknown variant").
+    // Strip it from a freshly laid-down template when the binary is known to
+    // be too old. A pre-existing ckb.toml is never edited here — that case is
+    // reported to the user by the caller instead of silently rewritten.
+    if (ckbTomlWasMissing && !supportsTerminalRpcModule(options.ckbVersion)) {
+      removeTerminalRpcModule(ckbTomlPath, options.ckbVersion ?? null);
+    }
   }
 
-  migrateLegacyDevnetRpcConfig(devnetConfigPath);
+  migrateLegacyDevnetRpcConfig(devnetConfigPath, options.ckbVersion);
 }
 
 const TERMINAL_RPC_MODULE = 'Terminal';
 const DEFAULT_TCP_LISTEN_ADDRESS = '127.0.0.1:18114';
+
+// The Terminal RPC module (nervosnetwork/ckb#4989) first shipped in CKB
+// v0.205.0. Older binaries fail config deserialization on it at startup.
+export const TERMINAL_RPC_MIN_CKB_VERSION = '0.205.0';
+
+// Unknown (null/undefined/unparseable) versions keep the historical behavior
+// of assuming support — a custom binary whose version cannot be probed must
+// not lose functionality it may actually have.
+export function supportsTerminalRpcModule(ckbVersion: string | null | undefined): boolean {
+  if (ckbVersion == null || !semver.valid(ckbVersion)) return true;
+  return semver.gte(ckbVersion, TERMINAL_RPC_MIN_CKB_VERSION);
+}
+
+// Whether the chain's ckb.toml currently enables the Terminal RPC module.
+// Unreadable or invalid configs report false and are left for CKB itself to
+// complain about.
+export function devnetConfigHasTerminalRpc(devnetConfigPath: string): boolean {
+  try {
+    const ckbTomlPath = path.join(devnetConfigPath, 'ckb.toml');
+    if (!fs.existsSync(ckbTomlPath)) return false;
+    const parsed = toml.parse(fs.readFileSync(ckbTomlPath, 'utf8'));
+    const rpc = parsed.rpc as JsonMap | undefined;
+    const modules = rpc?.modules;
+    return (
+      Array.isArray(modules) && modules.every((m) => typeof m === 'string') && modules.includes(TERMINAL_RPC_MODULE)
+    );
+  } catch {
+    return false;
+  }
+}
 
 function findRpcSection(lines: string[]): { start: number; end: number } | null {
   const start = lines.findIndex((line) => /^\s*\[rpc\]\s*$/.test(line));
@@ -90,6 +143,59 @@ function addTerminalModule(lines: string[], section: { start: number; end: numbe
   return true;
 }
 
+// Inverse of addTerminalModule: drops "Terminal" from the rpc.modules array,
+// preserving the file's formatting. Handles the single-line template layout
+// and hand-formatted multi-line arrays.
+function removeTerminalModule(lines: string[], section: { start: number; end: number }): boolean {
+  const modulesStart = lines.findIndex(
+    (line, index) => index > section.start && index < section.end && /^\s*modules\s*=\s*\[/.test(line),
+  );
+  if (modulesStart < 0) return false;
+
+  if (lines[modulesStart].includes(']')) {
+    const line = lines[modulesStart];
+    // Terminal last (the bundled template), Terminal first, or Terminal alone.
+    let updated = line.replace(/,\s*"Terminal"/, '');
+    if (updated === line) updated = line.replace(/"Terminal"\s*,\s*/, '');
+    if (updated === line) updated = line.replace(/\[\s*"Terminal"\s*\]/, '[]');
+    if (updated === line) return false;
+    lines[modulesStart] = updated;
+    return true;
+  }
+
+  // Multi-line array: drop the line holding the Terminal entry.
+  for (let i = modulesStart + 1; i < section.end; i++) {
+    if (/^\s*"Terminal",?\s*$/.test(lines[i])) {
+      lines.splice(i, 1);
+      return true;
+    }
+    if (lines[i].includes(']')) break;
+  }
+  return false;
+}
+
+// Removes the Terminal RPC module from a ckb.toml known to be the bundled
+// template, for CKB versions too old to support it. Text-based like the
+// migration so the template's comments survive; failure is non-fatal and
+// simply leaves the template as-is (CKB then reports the config error).
+function removeTerminalRpcModule(ckbTomlPath: string, ckbVersion: string | null) {
+  try {
+    const source = fs.readFileSync(ckbTomlPath, 'utf8');
+    const lines = source.split('\n');
+    const section = findRpcSection(lines);
+    if (section == null) return;
+    if (!removeTerminalModule(lines, section)) return;
+
+    fs.writeFileSync(ckbTomlPath, lines.join('\n'), 'utf8');
+    logger.info(
+      `CKB ${ckbVersion ?? '< 0.205.0'} does not support the Terminal RPC module; removed it from the new devnet ckb.toml. ` +
+        `The system-metric panels of \`offckb status\` (ckb-tui) require CKB >= ${TERMINAL_RPC_MIN_CKB_VERSION}.`,
+    );
+  } catch (error) {
+    logger.debug(`skipping Terminal RPC module removal: ${(error as Error).message}`);
+  }
+}
+
 // Enables rpc.tcp_listen_address. Only the stock loopback default is
 // uncommented in place — a commented non-loopback value (e.g. 0.0.0.0) stays
 // disabled and a fresh loopback entry is inserted after the modules array
@@ -126,9 +232,14 @@ function enableTcpListenAddress(lines: string[], section: { start: number; end: 
  * fresh config folders, so chains initialized before that change never picked
  * it up. Edits are text-based to keep user comments/formatting intact, and
  * any failure is non-fatal — node startup must never break over a migration.
- * Returns true when the file was changed.
+ *
+ * When ckbVersion is known to predate the Terminal RPC module (< 0.205.0),
+ * Terminal is NOT added — otherwise every `offckb node` start would re-add
+ * what the user removed and crash the old binary at startup. The
+ * tcp_listen_address half predates 0.205.0 by a wide margin and still
+ * applies. Returns true when the file was changed.
  */
-export function migrateLegacyDevnetRpcConfig(devnetConfigPath: string): boolean {
+export function migrateLegacyDevnetRpcConfig(devnetConfigPath: string, ckbVersion?: string | null): boolean {
   const ckbTomlPath = path.join(devnetConfigPath, 'ckb.toml');
   try {
     if (!fs.existsSync(ckbTomlPath)) return false;
@@ -140,7 +251,10 @@ export function migrateLegacyDevnetRpcConfig(devnetConfigPath: string): boolean 
 
     const modules = rpc.modules;
     const needsTerminal =
-      Array.isArray(modules) && modules.every((m) => typeof m === 'string') && !modules.includes(TERMINAL_RPC_MODULE);
+      supportsTerminalRpcModule(ckbVersion) &&
+      Array.isArray(modules) &&
+      modules.every((m) => typeof m === 'string') &&
+      !modules.includes(TERMINAL_RPC_MODULE);
     const tcpAddress = rpc.tcp_listen_address;
     const needsTcp = typeof tcpAddress !== 'string' || tcpAddress.trim().length === 0;
     if (!needsTerminal && !needsTcp) return false;

--- a/tests/init-chain.test.ts
+++ b/tests/init-chain.test.ts
@@ -16,7 +16,7 @@ jest.mock('../src/util/logger', () => ({
   logger: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }));
 
-import { initChainIfNeeded, migrateLegacyDevnetRpcConfig } from '../src/node/init-chain';
+import { initChainIfNeeded, migrateLegacyDevnetRpcConfig, supportsTerminalRpcModule } from '../src/node/init-chain';
 
 const LEGACY_CKB_TOML = `# legacy devnet config from before the ckb-tui fix
 # a custom comment that must survive migration
@@ -204,5 +204,127 @@ describe('migrateLegacyDevnetRpcConfig', () => {
 
   it('returns false when ckb.toml does not exist', () => {
     expect(migrateLegacyDevnetRpcConfig(mockConfigPath)).toBe(false);
+  });
+});
+
+describe('Terminal RPC module version gating', () => {
+  let root: string;
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-terminal-gate-'));
+    mockConfigPath = path.join(root, 'devnet');
+  });
+  afterEach(() => fs.rmSync(root, { recursive: true, force: true }));
+
+  it('treats unknown or unparseable versions as Terminal-capable', () => {
+    expect(supportsTerminalRpcModule(null)).toBe(true);
+    expect(supportsTerminalRpcModule(undefined)).toBe(true);
+    expect(supportsTerminalRpcModule('not-a-version')).toBe(true);
+    expect(supportsTerminalRpcModule('0.205.0')).toBe(true);
+    expect(supportsTerminalRpcModule('0.207.0')).toBe(true);
+    expect(supportsTerminalRpcModule('0.120.0')).toBe(false);
+    expect(supportsTerminalRpcModule('0.204.9')).toBe(false);
+    expect(supportsTerminalRpcModule('0.205.0-rc1')).toBe(false);
+  });
+
+  it('strips Terminal from a freshly initialized template when the binary is too old', async () => {
+    await initChainIfNeeded({ ckbVersion: '0.120.0' });
+
+    const rpc = readCkbToml(mockConfigPath).rpc as JsonMap;
+    expect(rpc.modules).not.toContain('Terminal');
+    expect(rpc.modules).toContain('Indexer');
+    // tcp_listen_address predates 0.205.0 and stays enabled.
+    expect(rpc.tcp_listen_address).toBe('127.0.0.1:18114');
+    expect(fs.existsSync(path.join(mockConfigPath, 'ckb-miner.toml'))).toBe(true);
+  });
+
+  it('keeps Terminal on fresh init for new or unknown versions', async () => {
+    await initChainIfNeeded({ ckbVersion: '0.207.0' });
+    expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+
+    const second = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-terminal-gate-'));
+    try {
+      mockConfigPath = path.join(second, 'devnet');
+      await initChainIfNeeded();
+      expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+    } finally {
+      fs.rmSync(second, { recursive: true, force: true });
+    }
+  });
+
+  it('never strips a pre-existing ckb.toml, even when the binary is too old', async () => {
+    const withTerminal = LEGACY_CKB_TOML.replace(
+      'modules = ["Net", "Pool", "Miner", "Chain", "Stats", "Subscription", "Experiment", "Debug", "Indexer"]',
+      'modules = ["Net", "Chain", "Terminal"]',
+    );
+    fs.mkdirSync(path.join(mockConfigPath, 'specs'), { recursive: true });
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb.toml'), withTerminal);
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb-miner.toml'), 'custom-miner');
+    fs.writeFileSync(path.join(mockConfigPath, 'specs', 'dev.toml'), 'custom-spec');
+
+    await initChainIfNeeded({ ckbVersion: '0.120.0' });
+
+    expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+  });
+
+  it('migration does not re-add Terminal for an old binary, but still enables tcp', () => {
+    fs.mkdirSync(mockConfigPath, { recursive: true });
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb.toml'), LEGACY_CKB_TOML);
+
+    expect(migrateLegacyDevnetRpcConfig(mockConfigPath, '0.120.0')).toBe(true);
+
+    const rpc = readCkbToml(mockConfigPath).rpc as JsonMap;
+    expect(rpc.modules).not.toContain('Terminal');
+    expect(rpc.tcp_listen_address).toBe('127.0.0.1:18114');
+  });
+
+  it('migration is a no-op for an old binary once tcp is set, breaking the remove/re-add loop', () => {
+    fs.mkdirSync(mockConfigPath, { recursive: true });
+    const tcpOnly = LEGACY_CKB_TOML.replace(
+      '# tcp_listen_address = "127.0.0.1:18114"',
+      'tcp_listen_address = "127.0.0.1:18114"',
+    );
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb.toml'), tcpOnly);
+    const before = fs.readFileSync(path.join(mockConfigPath, 'ckb.toml'), 'utf8');
+
+    expect(migrateLegacyDevnetRpcConfig(mockConfigPath, '0.120.0')).toBe(false);
+    expect(fs.readFileSync(path.join(mockConfigPath, 'ckb.toml'), 'utf8')).toBe(before);
+  });
+
+  it('migration still adds Terminal for new and unknown versions', () => {
+    fs.mkdirSync(mockConfigPath, { recursive: true });
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb.toml'), LEGACY_CKB_TOML);
+    expect(migrateLegacyDevnetRpcConfig(mockConfigPath, '0.207.0')).toBe(true);
+    expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+
+    fs.writeFileSync(path.join(mockConfigPath, 'ckb.toml'), LEGACY_CKB_TOML);
+    expect(migrateLegacyDevnetRpcConfig(mockConfigPath, null)).toBe(true);
+    expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+  });
+
+  it('preserves a pre-existing hand-formatted multi-line config when the binary is too old', async () => {
+    // Fresh init strips Terminal from the single-line bundled template...
+    await initChainIfNeeded({ ckbVersion: '0.120.0' });
+    const stripped = readCkbToml(mockConfigPath).rpc as JsonMap;
+    expect(stripped.modules).not.toContain('Terminal');
+
+    // ...but once ckb.toml exists — even reformatted by hand — re-init must
+    // not edit it; reporting Terminal+old-binary is node startup's job.
+    const second = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-terminal-gate-'));
+    try {
+      mockConfigPath = path.join(second, 'devnet');
+      await initChainIfNeeded();
+      const ckbTomlPath = path.join(mockConfigPath, 'ckb.toml');
+      const singleLine = fs.readFileSync(ckbTomlPath, 'utf8');
+      const multiline = singleLine.replace(
+        /modules = \[[^\]]*\]/,
+        'modules = [\n  "Net",\n  "Chain",\n  "Terminal",\n]',
+      );
+      expect(multiline).not.toBe(singleLine);
+      fs.writeFileSync(ckbTomlPath, multiline);
+      await initChainIfNeeded({ ckbVersion: '0.120.0' });
+      expect((readCkbToml(mockConfigPath).rpc as JsonMap).modules).toContain('Terminal');
+    } finally {
+      fs.rmSync(second, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/node-supervisor.test.ts
+++ b/tests/node-supervisor.test.ts
@@ -12,7 +12,10 @@ jest.mock('child_process', () => ({
   spawn: (...args: unknown[]) => mockSpawn(...args),
 }));
 jest.mock('../src/node/install', () => ({ installCKBBinary: jest.fn().mockResolvedValue(undefined) }));
-jest.mock('../src/node/init-chain', () => ({ initChainIfNeeded: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/node/init-chain', () => ({
+  ...jest.requireActual('../src/node/init-chain'),
+  initChainIfNeeded: jest.fn().mockResolvedValue(undefined),
+}));
 jest.mock('../src/cfg/setting', () => ({
   readSettings: () => ({
     bins: { defaultCKBVersion: '0.207.0' },
@@ -123,7 +126,9 @@ describe('foreground devnet supervisor', () => {
     await nodeDevnet({});
 
     expect(mockMarkForkFirstRunComplete).toHaveBeenCalledWith('/tmp/offckb-devnet', '100');
-    expect(mockMarkForkFirstRunComplete.mock.invocationCallOrder[0]).toBeLessThan(mockSpawn.mock.invocationCallOrder[1]);
+    expect(mockMarkForkFirstRunComplete.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSpawn.mock.invocationCallOrder[1],
+    );
     expect(mockProxyStart).toHaveBeenCalled();
   });
 });

--- a/tests/node-terminal-rpc.test.ts
+++ b/tests/node-terminal-rpc.test.ts
@@ -1,0 +1,208 @@
+import { EventEmitter } from 'events';
+import { startNode } from '../src/cmd/node';
+import { Network } from '../src/type/base';
+
+const mockSpawn = jest.fn();
+const mockGetVersionFromBinary = jest.fn();
+const mockInstallCKBBinary = jest.fn();
+const mockInitChainIfNeeded = jest.fn();
+const mockDevnetConfigHasTerminalRpc = jest.fn();
+const mockWaitForNodeReady = jest.fn();
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+jest.mock('../src/node/install', () => ({
+  installCKBBinary: (...args: unknown[]) => mockInstallCKBBinary(...args),
+  getVersionFromBinary: (...args: unknown[]) => mockGetVersionFromBinary(...args),
+}));
+
+jest.mock('../src/node/init-chain', () => ({
+  ...jest.requireActual('../src/node/init-chain'),
+  initChainIfNeeded: (...args: unknown[]) => mockInitChainIfNeeded(...args),
+  devnetConfigHasTerminalRpc: (...args: unknown[]) => mockDevnetConfigHasTerminalRpc(...args),
+}));
+
+jest.mock('../src/tools/rpc-proxy', () => ({
+  createRPCProxy: jest.fn(() => ({
+    start: jest.fn(),
+    stop: jest.fn(),
+  })),
+}));
+
+jest.mock('../src/devnet/readiness', () => ({
+  checkNodeReadiness: jest.fn().mockResolvedValue({ ready: false, rpcUrl: 'http://127.0.0.1:8114' }),
+  waitForNodeReady: (...args: unknown[]) => mockWaitForNodeReady(...args),
+}));
+
+jest.mock('../src/devnet/fork', () => ({
+  readForkState: jest.fn(() => null),
+  markForkFirstRunComplete: jest.fn(),
+}));
+
+jest.mock('../src/cfg/setting', () => ({
+  readSettings: () => ({
+    bins: { defaultCKBVersion: '0.207.0' },
+    devnet: {
+      configPath: '/tmp/offckb-devnet-config',
+      dataPath: '/tmp/offckb-devnet-data',
+      rpcUrl: 'http://127.0.0.1:8114',
+      rpcProxyPort: 28114,
+    },
+  }),
+  getCKBBinaryPath: (version: string) => `/managed/ckb/${version}/ckb`,
+}));
+
+jest.mock('../src/util/logger', () => ({
+  logger: {
+    success: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    result: jest.fn(),
+    setJsonMode: jest.fn(),
+  },
+}));
+
+import { logger } from '../src/util/logger';
+
+// A minimal stand-in for a spawned ChildProcess: event emitter plus piped
+// stdio emitters. `once('spawn')` fires on the next tick so waitForChildSpawn
+// resolves without the test orchestrating timing.
+function makeFakeChild(pid: number) {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    pid: number;
+    killed: boolean;
+    kill: jest.Mock;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.pid = pid;
+  child.killed = false;
+  child.kill = jest.fn(() => {
+    child.killed = true;
+    return true;
+  });
+  const originalOnce = child.once.bind(child);
+  child.once = ((event: string | symbol, listener: (...args: unknown[]) => void) => {
+    if (event === 'spawn') process.nextTick(listener);
+    return originalOnce(event, listener);
+  }) as typeof child.once;
+  return child;
+}
+
+describe('node devnet Terminal RPC version handling', () => {
+  let ckbChild: ReturnType<typeof makeFakeChild>;
+  let minerChild: ReturnType<typeof makeFakeChild>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    ckbChild = makeFakeChild(1111);
+    minerChild = makeFakeChild(2222);
+    mockSpawn.mockReset();
+    mockSpawn.mockReturnValueOnce(ckbChild).mockReturnValueOnce(minerChild);
+    mockWaitForNodeReady.mockResolvedValue({ ready: true, rpcUrl: 'http://127.0.0.1:8114', nodeTip: 0n });
+    mockInstallCKBBinary.mockResolvedValue(undefined);
+    mockInitChainIfNeeded.mockResolvedValue(undefined);
+    mockDevnetConfigHasTerminalRpc.mockReturnValue(false);
+    mockGetVersionFromBinary.mockReturnValue(null);
+  });
+
+  it('passes the managed version to chain init and starts normally', async () => {
+    await startNode({ network: Network.devnet, version: '0.120.0' });
+
+    expect(mockInstallCKBBinary).toHaveBeenCalledWith('0.120.0');
+    expect(mockInitChainIfNeeded).toHaveBeenCalledWith({ ckbVersion: '0.120.0' });
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('predates the Terminal RPC module'));
+  });
+
+  it('uses the settings default version when none is given', async () => {
+    await startNode({ network: Network.devnet });
+
+    expect(mockInstallCKBBinary).toHaveBeenCalledWith('0.207.0');
+    expect(mockInitChainIfNeeded).toHaveBeenCalledWith({ ckbVersion: '0.207.0' });
+  });
+
+  it('probes a custom --binary-path version and forwards it to chain init', async () => {
+    mockGetVersionFromBinary.mockReturnValue('0.120.0');
+
+    await startNode({ network: Network.devnet, binaryPath: '/custom/ckb' });
+
+    expect(mockGetVersionFromBinary).toHaveBeenCalledWith('/custom/ckb');
+    expect(mockInstallCKBBinary).not.toHaveBeenCalled();
+    expect(mockInitChainIfNeeded).toHaveBeenCalledWith({ ckbVersion: '0.120.0' });
+  });
+
+  it('fails fast with an actionable error when the config has Terminal but the managed binary is too old', async () => {
+    mockDevnetConfigHasTerminalRpc.mockReturnValue(true);
+
+    await expect(startNode({ network: Network.devnet, version: '0.120.0' })).rejects.toThrow(
+      /requires CKB >= 0\.205\.0; the selected binary is 0\.120\.0/,
+    );
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when a probed custom binary is too old for the config', async () => {
+    mockGetVersionFromBinary.mockReturnValue('0.200.0');
+    mockDevnetConfigHasTerminalRpc.mockReturnValue(true);
+
+    await expect(startNode({ network: Network.devnet, binaryPath: '/custom/ckb' })).rejects.toThrow(
+      /remove "Terminal" from rpc\.modules/,
+    );
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('does not fail fast for an unprobeable custom binary (unknown version assumes support)', async () => {
+    mockGetVersionFromBinary.mockReturnValue(null);
+    mockDevnetConfigHasTerminalRpc.mockReturnValue(true);
+
+    await startNode({ network: Network.devnet, binaryPath: '/custom/ckb' });
+
+    expect(mockInitChainIfNeeded).toHaveBeenCalledWith({ ckbVersion: null });
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows a new-enough binary with a Terminal-enabled config', async () => {
+    mockDevnetConfigHasTerminalRpc.mockReturnValue(true);
+
+    await startNode({ network: Network.devnet, version: '0.207.0' });
+
+    expect(mockSpawn).toHaveBeenCalledTimes(2);
+    expect(logger.info).not.toHaveBeenCalledWith(expect.stringContaining('predates the Terminal RPC module'));
+  });
+
+  it('translates an "unknown variant `Terminal`" startup crash into an actionable error', async () => {
+    mockWaitForNodeReady.mockImplementation(async () => {
+      ckbChild.stderr.emit(
+        'data',
+        Buffer.from(
+          'Error: TOML parse error: unknown variant `Terminal`, expected one of `Net`, `Pool`, `Miner`, `Chain`',
+        ),
+      );
+      return { ready: false, error: 'CKB process exited' };
+    });
+
+    await expect(startNode({ network: Network.devnet, binaryPath: '/custom/ckb' })).rejects.toThrow(
+      /The "Terminal" RPC module requires CKB >= 0\.205\.0; remove "Terminal" from rpc\.modules/,
+    );
+  });
+
+  it('reports a plain startup failure when the stderr tail has no Terminal signature', async () => {
+    mockWaitForNodeReady.mockImplementation(async () => {
+      ckbChild.stderr.emit('data', Buffer.from('some unrelated panic'));
+      return { ready: false, error: 'CKB process exited' };
+    });
+
+    await expect(startNode({ network: Network.devnet, binaryPath: '/custom/ckb' })).rejects.toThrow(
+      /^CKB devnet failed to become ready: CKB process exited$/,
+    );
+  });
+});


### PR DESCRIPTION
## Problem

The devnet `ckb.toml` template enables the `Terminal` RPC module, which only exists since CKB **v0.205.0** (nervosnetwork/ckb#4989). For anyone running the devnet with an older CKB (`offckb node <旧版本>`, a pinned `defaultCKBVersion`, or `--binary-path`), the node aborts at startup with an opaque serde error:

```
unknown variant `Terminal`, expected one of `Net`, `Pool`, ...
```

Worse, `migrateLegacyDevnetRpcConfig` re-added `Terminal` on **every** `offckb node` start, so manually removing it from the config didn't help — an unbreakable crash loop that documentation alone could not fix.

## What this PR does

Node startup now resolves the effective CKB version (managed binaries know it by construction; a custom `--binary-path` is probed via the existing `getVersionFromBinary()`) and adapts:

1. **Fresh chains** for a pre-0.205.0 binary are initialized from the template with `Terminal` stripped (`tcp_listen_address` predates 0.205.0 and stays), with a log line noting the `offckb status` panels need ≥ 0.205.0.
2. **The legacy-config migration** no longer re-adds `Terminal` for such binaries — breaking the remove/re-add loop — while still enabling `tcp_listen_address`.
3. **Existing config with `Terminal` + old binary** fails fast *before* spawning CKB, with an actionable error naming the file, the required version, and the two remedies — replacing the serde dump.
4. **Unprobeable custom binaries** keep the historical behavior (assume support); if such a binary then crashes with the tell-tale `unknown variant `Terminal`` stderr, the startup error now appends a hint pointing at the actual cause (bounded 4 KB stderr tail).
5. **README**'s `status` section notes the CKB >= 0.205.0 requirement for the TUI's system-metric panels.

Pre-existing user configs are never silently rewritten — the strip applies only to a pristine, freshly copied template; everything else surfaces as a clear error.

## Test plan

- [x] `pnpm test` — 29 suites, 237 passed (21 in `init-chain`, 9 new in `node-terminal-rpc` covering version gating, fail-fast, probe fallback, and the stderr hint)
- [x] `tsc --noEmit` clean, `eslint` clean, `pnpm build` succeeds
- [x] Strip path verified against the real bundled template (fresh init with `0.120.0` produces a valid ckb.toml without `Terminal`, with `tcp_listen_address` intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)