### PR TITLE
feat: unify devnet logging with offckb logs and a quiet foreground node

### DIFF
--- a/.changeset/logs-command-quiet-node.md
+++ b/.changeset/logs-command-quiet-node.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': minor
+---
+
+Unify devnet logging around the node's log files and add `offckb logs`. A foreground `offckb node` no longer relays the raw node/miner stdout: the console now shows lifecycle events, live contract script debug output (`debug!` in scripts, streamed over the node's TCP log subscription), submitted transaction hashes, and RPC errors — the full node log stays in `data/logs/run.log` as always, and `--verbose` restores the old firehose. The new `offckb logs [node|script|miner|rpc] [-f] [--grep] [--tail]` command reads those log files (`docker logs` style), so logs are reachable in every run mode — foreground, daemon, or while `offckb status` is attached — and pipe/agent friendly. The RPC proxy is quieter too: per-request lines moved from info to debug, JSON-RPC errors in responses now surface as warnings, and everything the proxy sees is appended to `data/logs/proxy.log` (viewable via `offckb logs rpc`).

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Commands:
   balance [options] [toAddress]                 Check account balance, only devnet and testnet
   debugger                                      Port of the raw CKB Standalone Debugger
   status [options]                              Show ckb-tui status interface
+  logs [options] [target]                       Show devnet logs: node (default), contract script debug output, miner, or RPC proxy events
   config <action> [item] [value]                do a configuration action
   devnet config                                 Edit devnet configuration
   devnet info                                   Show fork metadata and node/indexer readiness
@@ -143,6 +144,21 @@ Stop the daemon later with:
 ```sh
 offckb node stop
 ```
+
+**View Logs**
+
+A foreground `offckb node` stays quiet by default: it prints lifecycle events, contract script debug output (`debug!` in your scripts), submitted transaction hashes, and RPC errors. The node, miner, and RPC proxy always write full logs to files under the devnet data folder, and `offckb logs` reads them in any run mode (foreground, daemon, or while `offckb status` is attached):
+
+```sh
+offckb logs                # node log (default)
+offckb logs script         # contract script debug output only
+offckb logs miner          # miner log
+offckb logs rpc            # RPC requests, transaction hashes, RPC errors
+offckb logs -f             # stream new lines, tail -f style
+offckb logs --tail 200 --grep ERROR
+```
+
+Use `offckb node --verbose` to restore the old behavior of printing the full raw node/miner output to the terminal.
 
 **Agent-Friendly JSON Output**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command, CommanderError, Option } from 'commander';
+import { Command, CommanderError, Option, Argument } from 'commander';
 import { startNode, stopNode } from './cmd/node';
 import { accounts } from './cmd/accounts';
 import { clean } from './cmd/clean';
@@ -15,6 +15,7 @@ import { devnetConfig } from './cmd/devnet-config';
 import { devnetFork } from './cmd/devnet-fork';
 import { devnetInfo } from './cmd/devnet-info';
 import { debugSingleScript, debugTransaction, parseSingleScriptOption } from './cmd/debug';
+import { logsCommand, LogsOptions } from './cmd/logs';
 import { printSystemScripts } from './cmd/system-scripts';
 import { transferAll } from './cmd/transfer-all';
 import { genSystemScriptsJsonFile } from './scripts/gen';
@@ -76,14 +77,41 @@ const nodeCommand = program
     'Specify the CKB binary path to use, only for devnet, when set, will ignore version and network',
   )
   .option('--daemon', 'Run the node in the background as a daemon (devnet only)')
-  .action(async (version: string, options: { network: Network; binaryPath?: string; daemon?: boolean }) => {
-    return startNode({ version, network: options.network, binaryPath: options.binaryPath, daemon: options.daemon });
-  });
+  .option('--verbose', 'Print the full raw node/miner output (default shows contract script output only)')
+  .action(
+    async (
+      version: string,
+      options: { network: Network; binaryPath?: string; daemon?: boolean; verbose?: boolean },
+    ) => {
+      return startNode({
+        version,
+        network: options.network,
+        binaryPath: options.binaryPath,
+        daemon: options.daemon,
+        verbose: options.verbose,
+      });
+    },
+  );
 
 nodeCommand
   .command('stop')
   .description('Stop the running CKB devnet daemon')
   .action(async () => stopNode());
+
+program
+  .command('logs')
+  .description('Show devnet logs: node (default), contract script debug output, miner, or RPC proxy events')
+  .addArgument(
+    new Argument('[target]', 'Which logs to show').choices(['node', 'script', 'miner', 'rpc']).default('node'),
+  )
+  .option('-f, --follow', 'Stream new log lines as they are written (like tail -f)')
+  .option('--grep <pattern>', 'Only show lines containing the given text')
+  .option('--tail <lines>', 'Show the last N lines before following', (value: string) => {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) throw new Error('--tail must be a non-negative integer');
+    return parsed;
+  })
+  .action((target: string, options: LogsOptions) => logsCommand(target, options));
 
 program
   .command('create [project-name]')

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { Command, CommanderError, Option, Argument } from 'commander';
+import { Command, CommanderError, InvalidArgumentError, Option, Argument } from 'commander';
 import { startNode, stopNode } from './cmd/node';
 import { accounts } from './cmd/accounts';
 import { clean } from './cmd/clean';
@@ -77,7 +77,10 @@ const nodeCommand = program
     'Specify the CKB binary path to use, only for devnet, when set, will ignore version and network',
   )
   .option('--daemon', 'Run the node in the background as a daemon (devnet only)')
-  .option('--verbose', 'Print the full raw node/miner output (default shows contract script output only)')
+  .option(
+    '--verbose',
+    'Print the full raw node/miner output (default shows lifecycle events, script output, tx hashes, and RPC errors)',
+  )
   .action(
     async (
       version: string,
@@ -108,7 +111,9 @@ program
   .option('--grep <pattern>', 'Only show lines containing the given text')
   .option('--tail <lines>', 'Show the last N lines before following', (value: string) => {
     const parsed = Number(value);
-    if (!Number.isInteger(parsed) || parsed < 0) throw new Error('--tail must be a non-negative integer');
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new InvalidArgumentError('--tail must be a non-negative integer');
+    }
     return parsed;
   })
   .action((target: string, options: LogsOptions) => logsCommand(target, options));

--- a/src/cmd/logs.ts
+++ b/src/cmd/logs.ts
@@ -1,0 +1,57 @@
+import {
+  LOG_TARGETS,
+  LogTarget,
+  SCRIPT_LOG_TARGET,
+  filterLinesByTarget,
+  followLogFile,
+  grepLines,
+  parseCkbLogLine,
+  readLogTail,
+  resolveLogPath,
+} from '../devnet/log-file';
+import { readSettings, Settings } from '../cfg/setting';
+import { logger as defaultLogger, UnifiedLogger } from '../util/logger';
+
+export interface LogsOptions {
+  follow?: boolean;
+  grep?: string;
+  tail?: number;
+}
+
+const DEFAULT_TAIL = 100;
+
+/**
+ * Print (and optionally follow) a devnet log file. The core is synchronous so
+ * it can be unit tested with temp files; --follow hands control to
+ * followLogFile and keeps the process alive until Ctrl-C.
+ */
+export function showLogs(target: LogTarget, options: LogsOptions, settings: Settings, logger: UnifiedLogger): void {
+  const filePath = resolveLogPath(target, settings);
+  const tail = options.tail ?? DEFAULT_TAIL;
+
+  let lines = readLogTail(filePath, tail);
+  const scriptOnly = target === 'script';
+  if (scriptOnly) lines = filterLinesByTarget(lines, SCRIPT_LOG_TARGET);
+  if (options.grep) lines = grepLines(lines, options.grep);
+  for (const line of lines) logger.info(line);
+
+  if (!options.follow) return;
+
+  let inScriptEntry = false;
+  followLogFile(filePath, (line) => {
+    let show = true;
+    if (scriptOnly) {
+      // Unparsable lines are continuations of the previous entry.
+      const parsed = parseCkbLogLine(line);
+      if (parsed) inScriptEntry = parsed.target === SCRIPT_LOG_TARGET;
+      show = inScriptEntry;
+    }
+    if (show && options.grep && !line.includes(options.grep)) show = false;
+    if (show) logger.info(line);
+  });
+}
+
+export function logsCommand(target: string | undefined, options: LogsOptions): void {
+  const resolved: LogTarget = LOG_TARGETS.includes(target as LogTarget) ? (target as LogTarget) : 'node';
+  showLogs(resolved, options, readSettings(), defaultLogger);
+}

--- a/src/cmd/node.ts
+++ b/src/cmd/node.ts
@@ -15,12 +15,15 @@ import { callJsonRpc } from '../util/json-rpc';
 import { Network } from '../type/base';
 import { logger } from '../util/logger';
 import { checkNodeReadiness, waitForNodeReady } from '../devnet/readiness';
+import { devnetTcpListenAddress, subscribeToNodeLogs, SubscriptionHandle } from '../devnet/log-subscription';
+import { SCRIPT_LOG_TARGET } from '../devnet/log-file';
 
 export interface NodeProp {
   version?: string;
   network?: Network;
   binaryPath?: string;
   daemon?: boolean;
+  verbose?: boolean;
 }
 
 interface PidMetadata {
@@ -43,7 +46,7 @@ function cleanChildOutput(data: unknown): string {
   return String(data).replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '');
 }
 
-export function startNode({ version, network = Network.devnet, binaryPath, daemon }: NodeProp) {
+export function startNode({ version, network = Network.devnet, binaryPath, daemon, verbose }: NodeProp) {
   if (binaryPath && network !== Network.devnet) {
     logger.warn('Custom binaryPath is only supported for devnet. The provided binaryPath will be ignored.');
   }
@@ -53,7 +56,7 @@ export function startNode({ version, network = Network.devnet, binaryPath, daemo
 
   switch (network) {
     case Network.devnet:
-      return nodeDevnet({ version, binaryPath, daemon });
+      return nodeDevnet({ version, binaryPath, daemon, verbose });
     case Network.testnet:
       return nodeTestnet();
     case Network.mainnet:
@@ -63,7 +66,7 @@ export function startNode({ version, network = Network.devnet, binaryPath, daemo
   }
 }
 
-export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
+export async function nodeDevnet({ version, binaryPath, daemon, verbose }: NodeProp) {
   if (daemon) {
     return startDaemon();
   }
@@ -119,14 +122,23 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   const runArgs = ['run', '-C', devnetConfigPath];
   if (firstRunFlags) runArgs.push('--skip-spec-check', '--overwrite-spec');
   const ckbProcess = spawn(ckbBinPath, runArgs, { stdio: ['ignore', 'pipe', 'pipe'] });
-  ckbProcess.stdout?.on('data', (data) => logger.info(['CKB:', cleanChildOutput(data)]));
+  // Quiet by default: the node keeps its full log in data/logs/run.log
+  // (see `offckb logs`), and contract script debug output streams over the
+  // TCP log subscription below. --verbose restores the raw stdout/stderr relay.
+  // stdout must be drained either way or the child blocks on a full pipe
+  // buffer once the OS pipe fills.
+  if (verbose) {
+    ckbProcess.stdout?.on('data', (data) => logger.info(['CKB:', cleanChildOutput(data)]));
+  } else {
+    ckbProcess.stdout?.on('data', () => {});
+  }
   // Keep a bounded stderr tail so a startup crash can be translated into an
   // actionable error below (CKB's own config errors are notoriously opaque).
   let ckbStderrTail = '';
   ckbProcess.stderr?.on('data', (data) => {
     const text = cleanChildOutput(data);
     ckbStderrTail = (ckbStderrTail + text).slice(-4096);
-    logger.error(['CKB error:', text]);
+    if (verbose) logger.error(['CKB error:', text]);
   });
 
   let ckbExited = false;
@@ -142,7 +154,10 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   if (!readiness.ready) {
     if (!ckbExited) ckbProcess.kill('SIGTERM');
     const hint = terminalRpcUnknownVariantHint(ckbStderrTail, devnetConfigPath);
-    throw new Error(`CKB devnet failed to become ready: ${readiness.error ?? 'CKB process exited'}${hint ?? ''}`);
+    throw new Error(
+      `CKB devnet failed to become ready: ${readiness.error ?? 'CKB process exited'}${hint ?? ''} ` +
+        'Check the node log with `offckb logs` or rerun with --verbose for full output.',
+    );
   }
   if (ckbExited) {
     throw new Error('CKB devnet exited immediately after its readiness check.');
@@ -164,8 +179,13 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
     ckbProcess.kill('SIGTERM');
     throw new Error(`CKB miner failed to start: ${(error as Error).message}`);
   }
-  minerProcess.stdout?.on('data', (data) => logger.info(['CKB-Miner:', cleanChildOutput(data)]));
-  minerProcess.stderr?.on('data', (data) => logger.error(['CKB-Miner error:', cleanChildOutput(data)]));
+  if (verbose) {
+    minerProcess.stdout?.on('data', (data) => logger.info(['CKB-Miner:', cleanChildOutput(data)]));
+    minerProcess.stderr?.on('data', (data) => logger.error(['CKB-Miner error:', cleanChildOutput(data)]));
+  } else {
+    minerProcess.stdout?.on('data', () => {});
+    minerProcess.stderr?.on('data', () => {});
+  }
   try {
     await waitForChildSpawn(minerProcess, 'CKB miner');
   } catch (error) {
@@ -179,7 +199,27 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
 
   const proxy = createRPCProxy(Network.devnet, settings.devnet.rpcUrl, settings.devnet.rpcProxyPort);
   proxy.start();
+
+  // Contract script debug output (debug! in scripts) streams live over the
+  // node's TCP log subscription; everything else stays in the log files.
+  let logSubscription: SubscriptionHandle | null = null;
+  const tcpAddress = devnetTcpListenAddress();
+  if (tcpAddress) {
+    logSubscription = subscribeToNodeLogs(
+      tcpAddress,
+      (entry) => {
+        if (entry.target === SCRIPT_LOG_TARGET) logger.info(['CKB-Script:', entry.message]);
+      },
+      (error) => logger.warn(`${error.message} Full logs remain available via: offckb logs -f`),
+    );
+  } else if (!verbose) {
+    logger.debug('No tcp_listen_address in ckb.toml; script debug output will not stream live.');
+  }
+
   logger.success(`CKB devnet is ready at ${settings.devnet.rpcUrl}.`);
+  if (!verbose) {
+    logger.info('Follow the full node log with: offckb logs -f');
+  }
   logger.result({
     command: 'node',
     network: Network.devnet,
@@ -194,6 +234,7 @@ export async function nodeDevnet({ version, binaryPath, daemon }: NodeProp) {
   const stopService = (component: 'CKB node' | 'CKB miner', code: number | null, signal: NodeJS.Signals | null) => {
     if (serviceStopping) return;
     serviceStopping = true;
+    logSubscription?.close();
     if (component !== 'CKB node' && !ckbProcess.killed) ckbProcess.kill('SIGTERM');
     if (component !== 'CKB miner' && !minerProcess.killed) minerProcess.kill('SIGTERM');
     proxy.stop();

--- a/src/cmd/node.ts
+++ b/src/cmd/node.ts
@@ -41,9 +41,15 @@ const NODE_READY_TIMEOUT_MS = 90_000;
 const FORK_NODE_READY_TIMEOUT_MS = 10 * 60_000;
 
 function cleanChildOutput(data: unknown): string {
-  // CKB colors its output even when it is redirected. Strip ANSI control
-  // sequences so JSON logs stay machine-readable.
-  return String(data).replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '');
+  // CKB colors its output even when it is redirected, and log text relayed
+  // from the node (including contract debug! messages) is untrusted terminal
+  // input. Strip ANSI CSI/OSC sequences and C0/C1 control characters (keeping
+  // \n and \t) so JSON logs stay machine-readable and a crafted script log
+  // cannot inject terminal control sequences.
+  return String(data)
+    .replace(/\u001b\[[0-?]*[ -/]*[@-~]/g, '')
+    .replace(/\u001b\][^\u0007\u001b]*(?:\u0007|\u001b\\)/g, '')
+    .replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, '');
 }
 
 export function startNode({ version, network = Network.devnet, binaryPath, daemon, verbose }: NodeProp) {
@@ -208,7 +214,7 @@ export async function nodeDevnet({ version, binaryPath, daemon, verbose }: NodeP
     logSubscription = subscribeToNodeLogs(
       tcpAddress,
       (entry) => {
-        if (entry.target === SCRIPT_LOG_TARGET) logger.info(['CKB-Script:', entry.message]);
+        if (entry.target === SCRIPT_LOG_TARGET) logger.info(['CKB-Script:', cleanChildOutput(entry.message)]);
       },
       (error) => logger.warn(`${error.message} Full logs remain available via: offckb logs -f`),
     );

--- a/src/cmd/status.ts
+++ b/src/cmd/status.ts
@@ -1,10 +1,8 @@
-import fs from 'fs';
-import path from 'path';
-import toml, { JsonMap } from '@iarna/toml';
 import { readSettings } from '../cfg/setting';
 import { CKBTui } from '../tools/ckb-tui';
 import { Network } from '../type/base';
 import { checkNodeReadiness } from '../devnet/readiness';
+import { devnetTcpListenAddress } from '../devnet/log-subscription';
 
 export interface StatusOptions {
   network: Network;
@@ -17,28 +15,6 @@ const NETWORK_SETTINGS_KEY: Record<Network, NetworkSettingsKey> = {
   [Network.testnet]: 'testnet',
   [Network.mainnet]: 'mainnet',
 };
-
-/**
- * Best-effort lookup of the devnet node's TCP subscription endpoint from its
- * ckb.toml. ckb-tui connects to it directly (the OffCKB proxy is HTTP-only) to
- * stream new/rejected transactions and logs; when absent, those dashboards
- * simply stay empty, so any failure here is non-fatal.
- */
-function devnetTcpListenAddress(): string | undefined {
-  try {
-    const settings = readSettings();
-    const ckbTomlPath = path.join(settings.devnet.configPath, 'ckb.toml');
-    if (!fs.existsSync(ckbTomlPath)) return undefined;
-    const parsed = toml.parse(fs.readFileSync(ckbTomlPath, 'utf8'));
-    const rpc = parsed.rpc as JsonMap | undefined;
-    const address = rpc?.tcp_listen_address;
-    if (typeof address !== 'string' || address.trim().length === 0) return undefined;
-    // A wildcard bind is not a dialable address; the node runs on this host.
-    return address.trim().replace(/^0\.0\.0\.0:/, '127.0.0.1:');
-  } catch {
-    return undefined;
-  }
-}
 
 export async function status({ network }: StatusOptions) {
   // ckb-tui is an interactive terminal UI. Running it without a TTY

--- a/src/devnet/log-file.ts
+++ b/src/devnet/log-file.ts
@@ -1,0 +1,152 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { Settings } from '../cfg/setting';
+import { Network } from '../type/base';
+
+/**
+ * Shared plumbing for the `offckb logs` command.
+ *
+ * CKB always writes its node log to `<data>/logs/run.log` and the miner log to
+ * `<data>/logs/miner.log` (log_to_file = true in the bundled config), and the
+ * RPC proxy appends its own events to `<data>/logs/proxy.log`. The files are
+ * the one log source that exists in every run mode (foreground, daemon, and
+ * while `offckb status` is attached), so the logs command is a thin reader
+ * over them instead of a new logging pipeline.
+ */
+
+export type LogTarget = 'node' | 'script' | 'miner' | 'rpc';
+export const LOG_TARGETS: LogTarget[] = ['node', 'script', 'miner', 'rpc'];
+
+export interface CkbLogLine {
+  timestamp: string;
+  thread: string;
+  level: string;
+  target: string;
+  message: string;
+}
+
+// 2026-07-29 11:31:27.149 +00:00 main INFO ckb_bin::subcommand::run  ckb version: ...
+// The level is NOT padded and the message is separated from the target by
+// whitespace (two spaces in practice; be lenient).
+const CKB_LOG_LINE = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}(?:\.\d+)? [+-]\d{2}:\d{2}) (\S+) ([A-Z]+) (\S+)\s+(.*)$/;
+
+export const SCRIPT_LOG_TARGET = 'ckb-script';
+
+export function parseCkbLogLine(line: string): CkbLogLine | null {
+  const match = line.match(CKB_LOG_LINE);
+  if (!match) return null;
+  return { timestamp: match[1], thread: match[2], level: match[3], target: match[4], message: match[5] };
+}
+
+/**
+ * Keep lines emitted by the given CKB log target. A line that does not parse
+ * (stack traces, multi-line contract debug output) belongs to the entry above
+ * it, so it is kept only when the preceding entry matched.
+ */
+export function filterLinesByTarget(lines: string[], target: string): string[] {
+  const kept: string[] = [];
+  let previousKept = false;
+  for (const line of lines) {
+    const parsed = parseCkbLogLine(line);
+    if (parsed) {
+      previousKept = parsed.target === target;
+      if (previousKept) kept.push(line);
+    } else if (previousKept) {
+      kept.push(line);
+    }
+  }
+  return kept;
+}
+
+export function tailLines(content: string, count: number): string[] {
+  const lines = content.split('\n');
+  // A trailing newline produces a final empty element that is not a log line.
+  if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+  return count >= lines.length ? lines : lines.slice(lines.length - count);
+}
+
+export function grepLines(lines: string[], pattern: string): string[] {
+  return lines.filter((line) => line.includes(pattern));
+}
+
+const LOG_FILE_NAMES: Record<Exclude<LogTarget, 'rpc'>, string> = {
+  node: 'run.log',
+  script: 'run.log',
+  miner: 'miner.log',
+};
+
+/**
+ * The proxy's event log. Derived from the per-network transactions path
+ * (`<root>/<network>/transactions`) so every network lands in its own data
+ * folder; for devnet this is `<devnet data>/logs/proxy.log`, next to run.log.
+ */
+export function proxyLogPathForNetwork(network: Network, settings: Settings): string {
+  return path.resolve(settings[network].transactionsPath, '..', 'data', 'logs', 'proxy.log');
+}
+
+export function resolveLogPath(target: LogTarget, settings: Settings): string {
+  if (target === 'rpc') return proxyLogPathForNetwork(Network.devnet, settings);
+  return path.join(settings.devnet.dataPath, 'logs', LOG_FILE_NAMES[target]);
+}
+
+export function readLogTail(filePath: string, count: number): string[] {
+  let content: string;
+  try {
+    content = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === 'ENOENT') {
+      throw new Error(
+        `Log file not found at ${filePath}. Start the devnet first (offckb node) and make sure ` +
+          'ckb.toml keeps log_to_file = true.',
+      );
+    }
+    throw error;
+  }
+  return tailLines(content, count);
+}
+
+/**
+ * Stream appended lines from a log file, `tail -f` style. Starts at the
+ * current end of file; reopen from offset 0 when the file is truncated or
+ * rotated away. Polling (fs.watchFile) is used instead of fs.watch because it
+ * behaves consistently across platforms and network filesystems. Returns a
+ * stop function.
+ */
+export function followLogFile(filePath: string, onLine: (line: string) => void, intervalMs = 250): () => void {
+  let offset = fs.existsSync(filePath) ? fs.statSync(filePath).size : 0;
+  let partial = '';
+
+  const onChange = (curr: fs.Stats, prev: fs.Stats) => {
+    if (curr.size < prev.size || curr.size < offset) {
+      // Truncated or rotated: restart from the beginning.
+      offset = 0;
+      partial = '';
+    }
+    if (curr.size === offset) return;
+
+    let fd: number;
+    try {
+      fd = fs.openSync(filePath, 'r');
+    } catch {
+      return; // briefly missing during rotation; next tick retries
+    }
+    try {
+      const length = curr.size - offset;
+      const buffer = Buffer.alloc(length);
+      fs.readSync(fd, buffer, 0, length, offset);
+      offset = curr.size;
+      const text = partial + buffer.toString('utf8');
+      const lines = text.split('\n');
+      partial = lines.pop() ?? '';
+      for (const line of lines) {
+        if (line.length > 0) onLine(line);
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
+  fs.watchFile(filePath, { interval: intervalMs }, onChange);
+  return () => fs.unwatchFile(filePath, onChange);
+}

--- a/src/devnet/log-file.ts
+++ b/src/devnet/log-file.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
+import { TextDecoder } from 'util';
 import { Settings } from '../cfg/setting';
 import { Network } from '../type/base';
 
@@ -116,12 +117,16 @@ export function readLogTail(filePath: string, count: number): string[] {
 export function followLogFile(filePath: string, onLine: (line: string) => void, intervalMs = 250): () => void {
   let offset = fs.existsSync(filePath) ? fs.statSync(filePath).size : 0;
   let partial = '';
+  // Streaming decoder: a multi-byte UTF-8 character split across two reads
+  // must not decode into replacement characters.
+  let decoder = new TextDecoder('utf-8');
 
   const onChange = (curr: fs.Stats, prev: fs.Stats) => {
     if (curr.size < prev.size || curr.size < offset) {
       // Truncated or rotated: restart from the beginning.
       offset = 0;
       partial = '';
+      decoder = new TextDecoder('utf-8');
     }
     if (curr.size === offset) return;
 
@@ -134,9 +139,11 @@ export function followLogFile(filePath: string, onLine: (line: string) => void, 
     try {
       const length = curr.size - offset;
       const buffer = Buffer.alloc(length);
-      fs.readSync(fd, buffer, 0, length, offset);
-      offset = curr.size;
-      const text = partial + buffer.toString('utf8');
+      // readSync may return fewer bytes than requested; only decode what was
+      // actually read and leave the rest for the next tick.
+      const bytesRead = fs.readSync(fd, buffer, 0, length, offset);
+      offset += bytesRead;
+      const text = partial + decoder.decode(buffer.subarray(0, bytesRead), { stream: true });
       const lines = text.split('\n');
       partial = lines.pop() ?? '';
       for (const line of lines) {

--- a/src/devnet/log-subscription.ts
+++ b/src/devnet/log-subscription.ts
@@ -1,0 +1,171 @@
+import * as net from 'net';
+import * as fs from 'fs';
+import * as path from 'path';
+import toml, { JsonMap } from '@iarna/toml';
+import { readSettings } from '../cfg/setting';
+
+/**
+ * Client for the CKB node's TCP JSON-RPC log subscription (the same channel
+ * ckb-tui uses). The node streams every log entry it emits as a structured
+ * { message, level, target, date } record, which lets the foreground node
+ * show contract script debug output without relaying raw stdout.
+ */
+
+/**
+ * Best-effort lookup of the devnet node's TCP subscription endpoint from its
+ * ckb.toml. Consumers connect to it directly (the OffCKB proxy is HTTP-only)
+ * to stream log entries; when absent, any failure here is non-fatal.
+ */
+export function devnetTcpListenAddress(): string | undefined {
+  try {
+    const settings = readSettings();
+    const ckbTomlPath = path.join(settings.devnet.configPath, 'ckb.toml');
+    if (!fs.existsSync(ckbTomlPath)) return undefined;
+    const parsed = toml.parse(fs.readFileSync(ckbTomlPath, 'utf8'));
+    const rpc = parsed.rpc as JsonMap | undefined;
+    const address = rpc?.tcp_listen_address;
+    if (typeof address !== 'string' || address.trim().length === 0) return undefined;
+    // A wildcard bind is not a dialable address; the node runs on this host.
+    return address.trim().replace(/^0\.0\.0\.0:/, '127.0.0.1:');
+  } catch {
+    return undefined;
+  }
+}
+
+export interface CkbLogEntry {
+  message: string;
+  level: string;
+  target: string;
+  date: string;
+}
+
+export interface SubscriptionHandle {
+  close(): void;
+}
+
+export interface SubscribeOptions {
+  maxAttempts?: number;
+  retryDelayMs?: number;
+}
+
+export function parseTcpListenAddress(address: string): { host: string; port: number } | null {
+  const match = address.match(/^(.+):(\d+)$/);
+  if (!match) return null;
+  const port = Number(match[2]);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) return null;
+  return { host: match[1], port };
+}
+
+export function parseSubscriptionMessage(line: string): { subscriptionId?: string; entry?: CkbLogEntry } | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (parsed == null || typeof parsed !== 'object') return null;
+  const message = parsed as Record<string, unknown>;
+
+  // Subscribe response: {"jsonrpc":"2.0","result":"<subscription id>","id":1}
+  if (typeof message.result === 'string' && message.id !== undefined) {
+    return { subscriptionId: message.result };
+  }
+
+  // Notification: {"jsonrpc":"2.0","method":"subscribe","params":{"result":{...entry},"subscription":"<id>"}}
+  if (message.method === 'subscribe' && message.params != null && typeof message.params === 'object') {
+    const params = message.params as Record<string, unknown>;
+    const result = params.result;
+    if (result != null && typeof result === 'object') {
+      const entry = result as Record<string, unknown>;
+      if (typeof entry.message === 'string' && typeof entry.target === 'string') {
+        return {
+          entry: {
+            message: entry.message,
+            level: typeof entry.level === 'string' ? entry.level : '',
+            target: entry.target,
+            date: typeof entry.date === 'string' ? entry.date : '',
+          },
+        };
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Subscribe to the node's "log" topic. The initial connect retries briefly
+ * because the TCP listener can lag the HTTP RPC readiness check; after
+ * maxAttempts the failure is reported via onError exactly once and the client
+ * gives up (the full log remains available through `offckb logs -f`).
+ */
+export function subscribeToNodeLogs(
+  tcpAddress: string,
+  onEntry: (entry: CkbLogEntry) => void,
+  onError?: (error: Error) => void,
+  options: SubscribeOptions = {},
+): SubscriptionHandle {
+  const maxAttempts = options.maxAttempts ?? 10;
+  const retryDelayMs = options.retryDelayMs ?? 500;
+  const endpoint = parseTcpListenAddress(tcpAddress);
+
+  let socket: net.Socket | null = null;
+  let closed = false;
+  let attempts = 0;
+  let failedReported = false;
+
+  const fail = (error: Error) => {
+    if (failedReported || closed) return;
+    failedReported = true;
+    onError?.(error);
+  };
+
+  const connect = () => {
+    if (closed || endpoint == null) return;
+    attempts += 1;
+    const conn = net.connect(endpoint.port, endpoint.host);
+    socket = conn;
+    let buffer = '';
+
+    conn.on('connect', () => {
+      conn.write(JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'subscribe', params: ['log'] }) + '\n');
+    });
+    conn.on('data', (data) => {
+      buffer += data.toString('utf8');
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        const parsed = parseSubscriptionMessage(line);
+        if (parsed?.entry) onEntry(parsed.entry);
+      }
+    });
+    conn.on('error', (error) => {
+      if (closed) return;
+      if (attempts < maxAttempts) {
+        setTimeout(connect, retryDelayMs);
+      } else {
+        fail(new Error(`Log subscription to ${tcpAddress} failed after ${attempts} attempts: ${error.message}`));
+      }
+    });
+    conn.on('close', () => {
+      // The supervisor tears the whole service down when the node dies, so a
+      // dropped subscription mid-run needs no reconnect of its own.
+      if (socket === conn) socket = null;
+    });
+  };
+
+  if (endpoint == null) {
+    fail(new Error(`Log subscription address ${tcpAddress} is invalid.`));
+  } else {
+    connect();
+  }
+
+  return {
+    close() {
+      closed = true;
+      socket?.destroy();
+      socket = null;
+    },
+  };
+}

--- a/src/devnet/log-subscription.ts
+++ b/src/devnet/log-subscription.ts
@@ -113,6 +113,11 @@ export function subscribeToNodeLogs(
   let closed = false;
   let attempts = 0;
   let failedReported = false;
+  // Retries exist only to bridge the startup window where the TCP listener
+  // lags HTTP readiness; once a subscription was live, a later drop is
+  // terminal here (the supervisor tears the whole service down anyway).
+  let everConnected = false;
+  let retryTimer: NodeJS.Timeout | null = null;
 
   const fail = (error: Error) => {
     if (failedReported || closed) return;
@@ -122,12 +127,14 @@ export function subscribeToNodeLogs(
 
   const connect = () => {
     if (closed || endpoint == null) return;
+    retryTimer = null;
     attempts += 1;
     const conn = net.connect(endpoint.port, endpoint.host);
     socket = conn;
     let buffer = '';
 
     conn.on('connect', () => {
+      everConnected = true;
       conn.write(JSON.stringify({ id: 1, jsonrpc: '2.0', method: 'subscribe', params: ['log'] }) + '\n');
     });
     conn.on('data', (data) => {
@@ -142,8 +149,11 @@ export function subscribeToNodeLogs(
     });
     conn.on('error', (error) => {
       if (closed) return;
+      if (everConnected) return;
       if (attempts < maxAttempts) {
-        setTimeout(connect, retryDelayMs);
+        retryTimer = setTimeout(connect, retryDelayMs);
+        // A pending retry must not keep the process alive on its own.
+        retryTimer.unref();
       } else {
         fail(new Error(`Log subscription to ${tcpAddress} failed after ${attempts} attempts: ${error.message}`));
       }
@@ -164,6 +174,8 @@ export function subscribeToNodeLogs(
   return {
     close() {
       closed = true;
+      if (retryTimer) clearTimeout(retryTimer);
+      retryTimer = null;
       socket?.destroy();
       socket = null;
     },

--- a/src/tools/proxy-events.ts
+++ b/src/tools/proxy-events.ts
@@ -1,0 +1,110 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Testable core of the RPC proxy's logging behavior.
+ *
+ * The proxy keeps the console quiet by default (per-request lines at debug
+ * level) while surfacing the two signals users actually watch for —
+ * submitted transaction hashes and JSON-RPC errors — and mirrors everything
+ * into `<network data>/logs/proxy.log` so `offckb logs rpc` can replay it.
+ */
+
+export interface ProxyLogSink {
+  debug(...args: unknown[]): void;
+  info(...args: unknown[]): void;
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+export interface ProxyEventLog {
+  filePath: string;
+  event(text: string): void;
+}
+
+export interface ProxyEventContext {
+  sink: ProxyLogSink;
+  events: ProxyEventLog;
+  transactionsPath: string;
+  hashTransaction(tx: unknown): string;
+}
+
+/** Append-only writer for proxy.log. Directory creation is lazy and cached. */
+export function createProxyEventLog(filePath: string): ProxyEventLog {
+  let dirReady = false;
+  return {
+    filePath,
+    event(text: string) {
+      try {
+        if (!dirReady) {
+          fs.mkdirSync(path.dirname(filePath), { recursive: true });
+          dirReady = true;
+        }
+        fs.appendFileSync(filePath, `${new Date().toISOString()} ${text}\n`);
+      } catch {
+        // Logging must never break request forwarding.
+        dirReady = false;
+      }
+    },
+  };
+}
+
+interface JsonRpcRequestPayload {
+  method?: unknown;
+  params?: unknown;
+}
+
+export function handleProxyRequestBody(reqData: string, ctx: ProxyEventContext): void {
+  if (reqData.length === 0) return;
+
+  try {
+    const jsonRpcContent = JSON.parse(reqData) as JsonRpcRequestPayload;
+    const method = jsonRpcContent.method;
+    const params = jsonRpcContent.params;
+    ctx.sink.debug('RPC Req: ', method);
+    if (typeof method === 'string') {
+      ctx.events.event(`request ${method}`);
+    }
+
+    if (method === 'send_transaction') {
+      const tx = (params as unknown[])[0];
+      const txHash = ctx.hashTransaction(tx);
+      if (!fs.existsSync(ctx.transactionsPath)) {
+        fs.mkdirSync(ctx.transactionsPath, { recursive: true });
+      }
+      const txFile = path.resolve(ctx.transactionsPath, `${txHash}.json`);
+      fs.writeFileSync(txFile, JSON.stringify(tx, null, 2));
+      // The hash line mirrors the RPC method name on purpose: at request time
+      // the proxy does not yet know whether the node will accept the tx, and
+      // any rejection surfaces separately as an RPC error line.
+      ctx.sink.info(`send_transaction: ${txHash}`);
+      ctx.events.event(`send_transaction ${txHash}`);
+    }
+  } catch (err) {
+    ctx.sink.error('Error parsing JSON-RPC req content:', (err as Error).message);
+  }
+}
+
+interface JsonRpcErrorPayload {
+  error?: { code?: unknown; message?: unknown };
+}
+
+export function handleProxyResponseBody(res: string, contentType: string | undefined, ctx: ProxyEventContext): void {
+  if (res.length === 0) return;
+  if (contentType !== 'application/json') return;
+  if (!res.trim().startsWith('{') && !res.trim().startsWith('[')) return;
+
+  try {
+    const parsed = JSON.parse(res) as JsonRpcErrorPayload | JsonRpcErrorPayload[];
+    const entries = Array.isArray(parsed) ? parsed : [parsed];
+    for (const entry of entries) {
+      if (entry?.error == null) continue;
+      const code = entry.error.code ?? 'unknown';
+      const message = entry.error.message ?? 'unknown error';
+      ctx.sink.warn(`RPC error: [${code}] ${message}`);
+      ctx.events.event(`error [${code}] ${message}`);
+    }
+  } catch (err) {
+    ctx.sink.error('Error parsing JSON-RPC res content:', (err as Error).message);
+  }
+}

--- a/src/tools/proxy-events.ts
+++ b/src/tools/proxy-events.ts
@@ -29,9 +29,29 @@ export interface ProxyEventContext {
   hashTransaction(tx: unknown): string;
 }
 
-/** Append-only writer for proxy.log. Directory creation is lazy and cached. */
-export function createProxyEventLog(filePath: string): ProxyEventLog {
+/**
+ * One event is exactly one line in proxy.log: RPC method names and error
+ * messages come from the proxied payloads, so embedded newlines or control
+ * characters would otherwise forge log records or corrupt `offckb logs rpc`
+ * output. Sanitizing here covers every call site.
+ */
+function sanitizeEventText(text: string): string {
+  return text.replace(/[\u0000-\u001f\u007f-\u009f]/g, ' ');
+}
+
+/** Default size cap for proxy.log; past it the file rolls over once to .1. */
+export const PROXY_LOG_MAX_BYTES = 10 * 1024 * 1024;
+
+/**
+ * Append-only writer for proxy.log. Directory creation is lazy and cached.
+ * Growth is bounded: once the file passes maxBytes it is renamed to
+ * `<file>.1` (single rollover, replacing any previous one) and restarted.
+ */
+export function createProxyEventLog(filePath: string, maxBytes = PROXY_LOG_MAX_BYTES): ProxyEventLog {
   let dirReady = false;
+  // In-memory size estimate so the cap costs no extra stat per event;
+  // -1 means "not measured yet" and is re-read lazily.
+  let size = -1;
   return {
     filePath,
     event(text: string) {
@@ -40,10 +60,19 @@ export function createProxyEventLog(filePath: string): ProxyEventLog {
           fs.mkdirSync(path.dirname(filePath), { recursive: true });
           dirReady = true;
         }
-        fs.appendFileSync(filePath, `${new Date().toISOString()} ${text}\n`);
+        const line = `${new Date().toISOString()} ${sanitizeEventText(text)}\n`;
+        if (size < 0) size = fs.existsSync(filePath) ? fs.statSync(filePath).size : 0;
+        if (size > 0 && size + Buffer.byteLength(line) > maxBytes) {
+          fs.rmSync(`${filePath}.1`, { force: true });
+          fs.renameSync(filePath, `${filePath}.1`);
+          size = 0;
+        }
+        fs.appendFileSync(filePath, line);
+        size += Buffer.byteLength(line);
       } catch {
         // Logging must never break request forwarding.
         dirReady = false;
+        size = -1;
       }
     },
   };
@@ -91,7 +120,10 @@ interface JsonRpcErrorPayload {
 
 export function handleProxyResponseBody(res: string, contentType: string | undefined, ctx: ProxyEventContext): void {
   if (res.length === 0) return;
-  if (contentType !== 'application/json') return;
+  // Real servers answer with parameters attached (application/json;
+  // charset=utf-8), so compare the bare media type, not the raw header.
+  const mediaType = (contentType ?? '').split(';')[0].trim().toLowerCase();
+  if (mediaType !== 'application/json') return;
   if (!res.trim().startsWith('{') && !res.trim().startsWith('[')) return;
 
   try {

--- a/src/tools/rpc-proxy.ts
+++ b/src/tools/rpc-proxy.ts
@@ -1,15 +1,27 @@
 import httpProxy from 'http-proxy';
 import http from 'http';
 import { Network } from '../type/base';
-import fs from 'fs';
 import { readSettings } from '../cfg/setting';
-import path from 'path';
 import { logger } from '../util/logger';
+import { proxyLogPathForNetwork } from '../devnet/log-file';
+import { createProxyEventLog, handleProxyRequestBody, handleProxyResponseBody } from './proxy-events';
 
 // todo: if we use import this throws error in tsc building
 const { cccA } = require('@ckb-ccc/core/advanced');
 
 export function createRPCProxy(network: Network, targetRpcUrl: string, port: number) {
+  const settings = readSettings();
+  const events = createProxyEventLog(proxyLogPathForNetwork(network, settings));
+  const ctx = {
+    sink: logger,
+    events,
+    transactionsPath: settings[network].transactionsPath,
+    hashTransaction: (tx: unknown) => {
+      const cccTx = cccA.JsonRpcTransformers.transactionTo(tx);
+      return cccTx.hash() as string;
+    },
+  };
+
   const proxy = httpProxy.createProxyServer({
     target: targetRpcUrl, // Target RPC server
     changeOrigin: true, // for https target to work
@@ -20,33 +32,7 @@ export function createRPCProxy(network: Network, targetRpcUrl: string, port: num
     req.on('data', (chunk) => {
       reqData += chunk;
     });
-    req.on('end', () => {
-      if (reqData.length === 0) return;
-
-      try {
-        const jsonRpcContent = JSON.parse(reqData);
-        const method = jsonRpcContent.method;
-        const params = jsonRpcContent.params;
-        logger.info('RPC Req: ', method);
-        logger.debug('RPC Params: ', params);
-
-        if (method === 'send_transaction') {
-          const tx = params[0];
-
-          const cccTx = cccA.JsonRpcTransformers.transactionTo(tx);
-          const txHash = cccTx.hash();
-          const settings = readSettings();
-          if (!fs.existsSync(settings[network].transactionsPath)) {
-            fs.mkdirSync(settings[network].transactionsPath);
-          }
-          const txFile = path.resolve(settings[network].transactionsPath, `${txHash}.json`);
-          fs.writeFileSync(txFile, JSON.stringify(tx, null, 2));
-          logger.info(`RPC Req:  store tx ${txHash}`);
-        }
-      } catch (err) {
-        logger.error('Error parsing JSON-RPC req content:', (err as Error).message);
-      }
-    });
+    req.on('end', () => handleProxyRequestBody(reqData, ctx));
   });
 
   proxy.on('proxyRes', function (proxyRes, _req, _res) {
@@ -56,16 +42,7 @@ export function createRPCProxy(network: Network, targetRpcUrl: string, port: num
     });
     proxyRes.on('end', function () {
       const res = Buffer.concat(body).toString('utf-8');
-      if (res.length === 0) return;
-      if (proxyRes.headers['content-type'] !== 'application/json') return;
-      if (!res.trim().startsWith('{') && !res.trim().startsWith('[')) return;
-
-      try {
-        const jsonRpcResponse = JSON.parse(res);
-        logger.debug('RPC Response: ', jsonRpcResponse);
-      } catch (err) {
-        logger.error('Error parsing JSON-RPC res content:', (err as Error).message);
-      }
+      handleProxyResponseBody(res, proxyRes.headers['content-type'], ctx);
     });
   });
 

--- a/tests/log-subscription.test.ts
+++ b/tests/log-subscription.test.ts
@@ -1,5 +1,28 @@
 import * as net from 'net';
+import { EventEmitter } from 'events';
 import { parseTcpListenAddress, parseSubscriptionMessage, subscribeToNodeLogs } from '../src/devnet/log-subscription';
+
+// connect is routed through a mock so retry behavior can be driven with a
+// fake socket; by default it delegates to the real implementation.
+const mockConnect = jest.fn();
+jest.mock('net', () => ({
+  ...jest.requireActual('net'),
+  connect: (...args: unknown[]) => mockConnect(...args),
+}));
+const realConnect = (jest.requireActual('net') as typeof net).connect;
+
+class FakeSocket extends EventEmitter {
+  written: string[] = [];
+  destroyed = false;
+  write(data: string): boolean {
+    this.written.push(data);
+    return true;
+  }
+  destroy(): this {
+    this.destroyed = true;
+    return this;
+  }
+}
 
 describe('parseTcpListenAddress', () => {
   it('splits host and port', () => {
@@ -51,6 +74,13 @@ describe('parseSubscriptionMessage', () => {
 });
 
 describe('subscribeToNodeLogs', () => {
+  beforeEach(() => {
+    mockConnect.mockReset();
+    mockConnect.mockImplementation((...args: unknown[]) =>
+      (realConnect as (...a: unknown[]) => net.Socket)(...args),
+    );
+  });
+
   it('subscribes over TCP and emits log entries until closed', async () => {
     const server = net.createServer((socket) => {
       socket.on('data', (data) => {
@@ -111,5 +141,47 @@ describe('subscribeToNodeLogs', () => {
     sub.close();
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toMatch(/log subscription/i);
+  });
+
+  it('does not reconnect once an established subscription drops', async () => {
+    const socket = new FakeSocket();
+    mockConnect.mockReturnValue(socket as unknown as net.Socket);
+    const errors: Error[] = [];
+    const sub = subscribeToNodeLogs('127.0.0.1:18114', () => {}, (err) => errors.push(err), {
+      maxAttempts: 3,
+      retryDelayMs: 30,
+    });
+
+    socket.emit('connect');
+    expect(socket.written.join('')).toContain('"subscribe"');
+    // A mid-run drop is terminal for the subscription (the supervisor tears
+    // the service down): no reconnect, no failure report.
+    socket.emit('error', new Error('read ECONNRESET'));
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(mockConnect).toHaveBeenCalledTimes(1);
+    expect(errors).toEqual([]);
+    sub.close();
+  });
+
+  it('close() cancels a reconnect pending from the initial connect phase', async () => {
+    const socket = new FakeSocket();
+    mockConnect.mockReturnValue(socket as unknown as net.Socket);
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+    const sub = subscribeToNodeLogs('127.0.0.1:18114', () => {}, () => {}, {
+      maxAttempts: 5,
+      retryDelayMs: 50,
+    });
+
+    try {
+      // The first attempt fails before ever connecting, so a retry is pending.
+      socket.emit('error', new Error('connect ECONNREFUSED'));
+      sub.close();
+      // The pending timer is cancelled, not left to no-op on the closed guard.
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    } finally {
+      clearTimeoutSpy.mockRestore();
+    }
   });
 });

--- a/tests/log-subscription.test.ts
+++ b/tests/log-subscription.test.ts
@@ -1,0 +1,115 @@
+import * as net from 'net';
+import { parseTcpListenAddress, parseSubscriptionMessage, subscribeToNodeLogs } from '../src/devnet/log-subscription';
+
+describe('parseTcpListenAddress', () => {
+  it('splits host and port', () => {
+    expect(parseTcpListenAddress('127.0.0.1:18114')).toEqual({ host: '127.0.0.1', port: 18114 });
+  });
+
+  it('rejects invalid addresses', () => {
+    expect(parseTcpListenAddress('no-port')).toBeNull();
+    expect(parseTcpListenAddress('127.0.0.1:notaport')).toBeNull();
+    expect(parseTcpListenAddress('')).toBeNull();
+  });
+});
+
+describe('parseSubscriptionMessage', () => {
+  it('parses the subscribe response into a subscription id', () => {
+    expect(parseSubscriptionMessage('{"jsonrpc":"2.0","result":"0x49af29b770e3502239e4510ff58f8d59","id":1}')).toEqual({
+      subscriptionId: '0x49af29b770e3502239e4510ff58f8d59',
+    });
+  });
+
+  it('parses a log notification into an entry', () => {
+    const line = JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'subscribe',
+      params: {
+        result: {
+          message: 'script group: 0xabcd DEBUG OUTPUT: hello',
+          level: 'DEBUG',
+          target: 'ckb-script',
+          date: '2026-07-29 11:40:01.500 +00:00',
+        },
+        subscription: '0x49af',
+      },
+    });
+    expect(parseSubscriptionMessage(line)).toEqual({
+      entry: {
+        message: 'script group: 0xabcd DEBUG OUTPUT: hello',
+        level: 'DEBUG',
+        target: 'ckb-script',
+        date: '2026-07-29 11:40:01.500 +00:00',
+      },
+    });
+  });
+
+  it('returns null for garbage and unrelated messages', () => {
+    expect(parseSubscriptionMessage('not json')).toBeNull();
+    expect(parseSubscriptionMessage('{"jsonrpc":"2.0","method":"other","params":{}}')).toBeNull();
+  });
+});
+
+describe('subscribeToNodeLogs', () => {
+  it('subscribes over TCP and emits log entries until closed', async () => {
+    const server = net.createServer((socket) => {
+      socket.on('data', (data) => {
+        const request = JSON.parse(data.toString().trim());
+        expect(request.method).toBe('subscribe');
+        expect(request.params).toEqual(['log']);
+        socket.write(JSON.stringify({ jsonrpc: '2.0', result: '0xsub', id: request.id }) + '\n');
+        socket.write(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'subscribe',
+            params: {
+              result: {
+                message: 'hello',
+                level: 'DEBUG',
+                target: 'ckb-script',
+                date: '2026-07-29 11:40:01.500 +00:00',
+              },
+              subscription: '0xsub',
+            },
+          }) + '\n',
+        );
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const port = (server.address() as net.AddressInfo).port;
+
+    const entries: unknown[] = [];
+    const errors: Error[] = [];
+    const sub = subscribeToNodeLogs(
+      `127.0.0.1:${port}`,
+      (entry) => entries.push(entry),
+      (err) => errors.push(err),
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    sub.close();
+    server.close();
+
+    expect(errors).toEqual([]);
+    expect(entries).toEqual([
+      { message: 'hello', level: 'DEBUG', target: 'ckb-script', date: '2026-07-29 11:40:01.500 +00:00' },
+    ]);
+  });
+
+  it('retries briefly then reports an error when the node is unreachable', async () => {
+    const errors: Error[] = [];
+    const sub = subscribeToNodeLogs(
+      '127.0.0.1:1',
+      () => {},
+      (err) => errors.push(err),
+      {
+        maxAttempts: 2,
+        retryDelayMs: 50,
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    sub.close();
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toMatch(/log subscription/i);
+  });
+});

--- a/tests/logs-command.test.ts
+++ b/tests/logs-command.test.ts
@@ -1,0 +1,84 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import winston from 'winston';
+import { showLogs } from '../src/cmd/logs';
+import { defaultSettings, Settings } from '../src/cfg/setting';
+import { UnifiedLogger } from '../src/util/logger';
+
+const NODE_LINE =
+  '2026-07-29 11:31:27.149 +00:00 main INFO ckb_bin::subcommand::run  ckb version: 0.207.0 (8f6cacf 2026-06-10)';
+const SCRIPT_LINE =
+  '2026-07-29 11:40:01.500 +00:00 GlobalRt-7 DEBUG ckb-script  script group: 0xabcd DEBUG OUTPUT: hello world';
+const ERROR_LINE =
+  '2026-07-29 11:31:38.636 +00:00 verify_blocks ERROR ckb_chain::verify  unverified_block_rx err: channel disconnected';
+
+interface WinstonInfo {
+  [Symbol.for('message')]?: string;
+}
+
+class CapturingTransport extends winston.transports.Console {
+  logs: string[] = [];
+  log(info: WinstonInfo, next: () => void) {
+    this.logs.push(info[Symbol.for('message')] ?? '');
+    next();
+  }
+}
+
+function fixture(): { settings: Settings; transport: CapturingTransport } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-cmd-'));
+  const settings = JSON.parse(JSON.stringify(defaultSettings)) as Settings;
+  settings.devnet.dataPath = path.join(root, 'devnet/data');
+  settings.devnet.transactionsPath = path.join(root, 'devnet/transactions');
+  const logDir = path.join(settings.devnet.dataPath, 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  fs.writeFileSync(path.join(logDir, 'run.log'), [NODE_LINE, SCRIPT_LINE, ERROR_LINE].join('\n') + '\n');
+  fs.writeFileSync(path.join(logDir, 'miner.log'), [ERROR_LINE].join('\n') + '\n');
+  fs.writeFileSync(path.join(logDir, 'proxy.log'), 'send_transaction 0xdeadbeef\n');
+  const transport = new CapturingTransport();
+  return { settings, transport };
+}
+
+describe('showLogs', () => {
+  it('prints the node log tail by default', () => {
+    const { settings, transport } = fixture();
+    const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+    showLogs('node', { tail: 100 }, settings, log);
+    expect(transport.logs).toEqual([NODE_LINE, SCRIPT_LINE, ERROR_LINE]);
+  });
+
+  it('prints only ckb-script lines for the script target', () => {
+    const { settings, transport } = fixture();
+    const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+    showLogs('script', { tail: 100 }, settings, log);
+    expect(transport.logs).toEqual([SCRIPT_LINE]);
+  });
+
+  it('reads miner.log for the miner target', () => {
+    const { settings, transport } = fixture();
+    const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+    showLogs('miner', { tail: 100 }, settings, log);
+    expect(transport.logs).toEqual([ERROR_LINE]);
+  });
+
+  it('reads proxy.log for the rpc target', () => {
+    const { settings, transport } = fixture();
+    const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+    showLogs('rpc', { tail: 100 }, settings, log);
+    expect(transport.logs).toEqual(['send_transaction 0xdeadbeef']);
+  });
+
+  it('honors --tail and --grep', () => {
+    const { settings, transport } = fixture();
+    const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+    showLogs('node', { tail: 2, grep: 'ERROR' }, settings, log);
+    expect(transport.logs).toEqual([ERROR_LINE]);
+  });
+
+  it('throws a helpful error when the log file does not exist', () => {
+    const settings = JSON.parse(JSON.stringify(defaultSettings)) as Settings;
+    settings.devnet.dataPath = '/nonexistent';
+    const log = UnifiedLogger.create({ transports: [new CapturingTransport()] });
+    expect(() => showLogs('node', { tail: 100 }, settings, log)).toThrow(/log file not found/i);
+  });
+});

--- a/tests/logs-command.test.ts
+++ b/tests/logs-command.test.ts
@@ -6,6 +6,16 @@ import { showLogs } from '../src/cmd/logs';
 import { defaultSettings, Settings } from '../src/cfg/setting';
 import { UnifiedLogger } from '../src/util/logger';
 
+// Same watcher stub as logs.test.ts: followLogFile's polling cadence belongs
+// to libuv, the tests drive change notifications directly.
+const mockWatchFile = jest.fn();
+const mockUnwatchFile = jest.fn();
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  watchFile: (...args: unknown[]) => mockWatchFile(...args),
+  unwatchFile: (...args: unknown[]) => mockUnwatchFile(...args),
+}));
+
 const NODE_LINE =
   '2026-07-29 11:31:27.149 +00:00 main INFO ckb_bin::subcommand::run  ckb version: 0.207.0 (8f6cacf 2026-06-10)';
 const SCRIPT_LINE =
@@ -25,8 +35,14 @@ class CapturingTransport extends winston.transports.Console {
   }
 }
 
+const tempRoots: string[] = [];
+afterEach(() => {
+  while (tempRoots.length) fs.rmSync(tempRoots.pop() as string, { recursive: true, force: true });
+});
+
 function fixture(): { settings: Settings; transport: CapturingTransport } {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-cmd-'));
+  tempRoots.push(root);
   const settings = JSON.parse(JSON.stringify(defaultSettings)) as Settings;
   settings.devnet.dataPath = path.join(root, 'devnet/data');
   settings.devnet.transactionsPath = path.join(root, 'devnet/transactions');
@@ -80,5 +96,38 @@ describe('showLogs', () => {
     settings.devnet.dataPath = '/nonexistent';
     const log = UnifiedLogger.create({ transports: [new CapturingTransport()] });
     expect(() => showLogs('node', { tail: 100 }, settings, log)).toThrow(/log file not found/i);
+  });
+
+  it('in follow mode gates script entries and applies grep to streamed lines', () => {
+    const { settings, transport } = fixture();
+    type StatListener = (curr: fs.Stats, prev: fs.Stats) => void;
+    const listeners: StatListener[] = [];
+    mockWatchFile.mockImplementation((_file: unknown, _options: unknown, onChange: StatListener) => {
+      listeners.push(onChange);
+    });
+
+    try {
+      const log = UnifiedLogger.create({ transports: [transport], showLevel: false });
+      showLogs('script', { tail: 100, follow: true, grep: 'hello' }, settings, log);
+      expect(listeners).toHaveLength(1);
+      // The tail already printed the one script line (it contains 'hello').
+      expect(transport.logs).toEqual([SCRIPT_LINE]);
+      transport.logs.length = 0;
+
+      const runLog = path.join(settings.devnet.dataPath, 'logs', 'run.log');
+      const scriptNoGrep = SCRIPT_LINE.replace('hello world', 'goodbye');
+      const scriptWithGrep = SCRIPT_LINE.replace('hello world', 'hello again');
+      fs.appendFileSync(runLog, [ERROR_LINE, scriptNoGrep, scriptWithGrep, '  hello continuation'].join('\n') + '\n');
+      const stat = fs.statSync(runLog);
+      listeners[0](stat, stat);
+
+      // ERROR_LINE is not a script entry; scriptNoGrep is filtered by grep;
+      // the continuation line belongs to the script entry above it and
+      // matches grep, so both it and scriptWithGrep are shown.
+      expect(transport.logs).toEqual([scriptWithGrep, '  hello continuation']);
+    } finally {
+      mockWatchFile.mockReset();
+      mockUnwatchFile.mockReset();
+    }
   });
 });

--- a/tests/logs.test.ts
+++ b/tests/logs.test.ts
@@ -1,0 +1,174 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import {
+  parseCkbLogLine,
+  filterLinesByTarget,
+  tailLines,
+  grepLines,
+  resolveLogPath,
+  readLogTail,
+  followLogFile,
+  LogTarget,
+} from '../src/devnet/log-file';
+import { defaultSettings, Settings } from '../src/cfg/setting';
+
+// fs.watchFile is a non-configurable property on the fs module, so spyOn
+// cannot stub it; route it through a mock factory instead. Everything else
+// keeps the real implementation.
+const mockWatchFile = jest.fn();
+const mockUnwatchFile = jest.fn();
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  watchFile: (...args: unknown[]) => mockWatchFile(...args),
+  unwatchFile: (...args: unknown[]) => mockUnwatchFile(...args),
+}));
+
+const NODE_LINE =
+  '2026-07-29 11:31:27.149 +00:00 main INFO ckb_bin::subcommand::run  ckb version: 0.207.0 (8f6cacf 2026-06-10)';
+const SCRIPT_LINE =
+  '2026-07-29 11:40:01.500 +00:00 GlobalRt-7 DEBUG ckb-script  script group: 0xabcd DEBUG OUTPUT: hello world';
+const ERROR_LINE =
+  '2026-07-29 11:31:38.636 +00:00 verify_blocks ERROR ckb_chain::verify  unverified_block_rx err: receiving on an empty and disconnected channel';
+
+function devnetSettings(root: string): Settings {
+  const settings = JSON.parse(JSON.stringify(defaultSettings)) as Settings;
+  settings.devnet.dataPath = path.join(root, 'devnet/data');
+  settings.devnet.transactionsPath = path.join(root, 'devnet/transactions');
+  return settings;
+}
+
+describe('parseCkbLogLine', () => {
+  it('parses a standard CKB log line into fields', () => {
+    expect(parseCkbLogLine(NODE_LINE)).toEqual({
+      timestamp: '2026-07-29 11:31:27.149 +00:00',
+      thread: 'main',
+      level: 'INFO',
+      target: 'ckb_bin::subcommand::run',
+      message: 'ckb version: 0.207.0 (8f6cacf 2026-06-10)',
+    });
+  });
+
+  it('parses a ckb-script debug line', () => {
+    const parsed = parseCkbLogLine(SCRIPT_LINE);
+    expect(parsed?.level).toBe('DEBUG');
+    expect(parsed?.target).toBe('ckb-script');
+    expect(parsed?.message).toBe('script group: 0xabcd DEBUG OUTPUT: hello world');
+  });
+
+  it('parses lines whose level is not padded', () => {
+    expect(parseCkbLogLine(ERROR_LINE)?.level).toBe('ERROR');
+    expect(parseCkbLogLine(ERROR_LINE)?.target).toBe('ckb_chain::verify');
+  });
+
+  it('returns null for continuation lines and garbage', () => {
+    expect(parseCkbLogLine('    at ckb_chain::verify (src/verify.rs:42)')).toBeNull();
+    expect(parseCkbLogLine('')).toBeNull();
+    expect(parseCkbLogLine('some random output')).toBeNull();
+  });
+});
+
+describe('filterLinesByTarget', () => {
+  it('keeps only lines from the given target plus their continuation lines', () => {
+    const lines = [
+      NODE_LINE,
+      SCRIPT_LINE,
+      '  continuation of the script message',
+      ERROR_LINE,
+      SCRIPT_LINE.replace('hello world', 'second'),
+    ];
+    expect(filterLinesByTarget(lines, 'ckb-script')).toEqual([
+      SCRIPT_LINE,
+      '  continuation of the script message',
+      SCRIPT_LINE.replace('hello world', 'second'),
+    ]);
+  });
+
+  it('drops leading unparsable lines when nothing matched before them', () => {
+    expect(filterLinesByTarget(['garbage line', SCRIPT_LINE], 'ckb-script')).toEqual([SCRIPT_LINE]);
+  });
+});
+
+describe('tailLines', () => {
+  it('returns the last N lines', () => {
+    expect(tailLines('a\nb\nc\nd\n', 2)).toEqual(['c', 'd']);
+  });
+
+  it('returns all lines when fewer than N exist', () => {
+    expect(tailLines('a\nb\n', 10)).toEqual(['a', 'b']);
+  });
+
+  it('returns an empty array for empty content', () => {
+    expect(tailLines('', 5)).toEqual([]);
+  });
+});
+
+describe('grepLines', () => {
+  it('keeps lines containing the substring', () => {
+    expect(grepLines([NODE_LINE, SCRIPT_LINE], 'DEBUG OUTPUT')).toEqual([SCRIPT_LINE]);
+  });
+});
+
+describe('resolveLogPath', () => {
+  const settings = devnetSettings('/data');
+  const logsDir = path.join(settings.devnet.dataPath, 'logs');
+  const cases: Array<[LogTarget, string]> = [
+    ['node', path.join(logsDir, 'run.log')],
+    ['script', path.join(logsDir, 'run.log')],
+    ['miner', path.join(logsDir, 'miner.log')],
+    // proxy.log resolves via transactionsPath and is made absolute.
+    ['rpc', path.resolve(settings.devnet.transactionsPath, '..', 'data', 'logs', 'proxy.log')],
+  ];
+  it.each(cases)('resolves %s logs to %s', (target, expected) => {
+    expect(resolveLogPath(target, settings)).toBe(expected);
+  });
+});
+
+describe('readLogTail (file reading)', () => {
+  it('reads the last N lines of a log file', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-'));
+    const file = path.join(dir, 'run.log');
+    fs.writeFileSync(file, [NODE_LINE, SCRIPT_LINE, ERROR_LINE].join('\n') + '\n');
+    expect(readLogTail(file, 2)).toEqual([SCRIPT_LINE, ERROR_LINE]);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('throws a helpful error when the file is missing', () => {
+    expect(() => readLogTail('/nonexistent/run.log', 10)).toThrow(/log file not found/i);
+  });
+});
+
+describe('followLogFile', () => {
+  it('emits appended lines until stopped', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-'));
+    const file = path.join(dir, 'run.log');
+    fs.writeFileSync(file, `${NODE_LINE}\n`);
+
+    // Stub the watcher plumbing: libuv's stat-polling cadence is Node's
+    // business (and proved flaky on CI runners), what we test is the offset
+    // tracking and line splitting once a change notification arrives.
+    type StatListener = (curr: fs.Stats, prev: fs.Stats) => void;
+    const listeners: StatListener[] = [];
+    mockWatchFile.mockImplementation((_file: unknown, _options: unknown, onChange: StatListener) => {
+      listeners.push(onChange);
+    });
+
+    try {
+      const seen: string[] = [];
+      const stop = followLogFile(file, (line) => seen.push(line));
+      expect(listeners).toHaveLength(1);
+
+      fs.appendFileSync(file, `${SCRIPT_LINE}\n`);
+      const stat = fs.statSync(file);
+      listeners[0](stat, stat);
+      stop();
+
+      expect(seen).toEqual([SCRIPT_LINE]);
+      expect(mockUnwatchFile).toHaveBeenCalled();
+    } finally {
+      mockWatchFile.mockReset();
+      mockUnwatchFile.mockReset();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/logs.test.ts
+++ b/tests/logs.test.ts
@@ -139,19 +139,28 @@ describe('readLogTail (file reading)', () => {
 });
 
 describe('followLogFile', () => {
-  it('emits appended lines until stopped', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-'));
-    const file = path.join(dir, 'run.log');
-    fs.writeFileSync(file, `${NODE_LINE}\n`);
-
-    // Stub the watcher plumbing: libuv's stat-polling cadence is Node's
-    // business (and proved flaky on CI runners), what we test is the offset
-    // tracking and line splitting once a change notification arrives.
-    type StatListener = (curr: fs.Stats, prev: fs.Stats) => void;
+  // Stub the watcher plumbing: libuv's stat-polling cadence is Node's
+  // business (and proved flaky on CI runners), what we test is the offset
+  // tracking and line splitting once a change notification arrives.
+  type StatListener = (curr: fs.Stats, prev: fs.Stats) => void;
+  function captureWatchListener(): StatListener[] {
     const listeners: StatListener[] = [];
     mockWatchFile.mockImplementation((_file: unknown, _options: unknown, onChange: StatListener) => {
       listeners.push(onChange);
     });
+    return listeners;
+  }
+
+  function tempLog(): { dir: string; file: string } {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-logs-'));
+    const file = path.join(dir, 'run.log');
+    fs.writeFileSync(file, `${NODE_LINE}\n`);
+    return { dir, file };
+  }
+
+  it('emits appended lines until stopped', () => {
+    const { dir, file } = tempLog();
+    const listeners = captureWatchListener();
 
     try {
       const seen: string[] = [];
@@ -165,6 +174,64 @@ describe('followLogFile', () => {
 
       expect(seen).toEqual([SCRIPT_LINE]);
       expect(mockUnwatchFile).toHaveBeenCalled();
+    } finally {
+      mockWatchFile.mockReset();
+      mockUnwatchFile.mockReset();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('re-reads from the beginning when the file is truncated or rotated', () => {
+    const { dir, file } = tempLog();
+    const listeners = captureWatchListener();
+
+    try {
+      const seen: string[] = [];
+      const stop = followLogFile(file, (line) => seen.push(line));
+
+      fs.appendFileSync(file, `${SCRIPT_LINE}\n`);
+      const grown = fs.statSync(file);
+      listeners[0](grown, grown);
+      expect(seen).toEqual([SCRIPT_LINE]);
+
+      // Rotation replaces the file with a shorter one; the next notification
+      // must reset the offset instead of seeking past the end.
+      fs.writeFileSync(file, `${ERROR_LINE}\n`);
+      listeners[0](fs.statSync(file), grown);
+      expect(seen).toEqual([SCRIPT_LINE, ERROR_LINE]);
+      stop();
+    } finally {
+      mockWatchFile.mockReset();
+      mockUnwatchFile.mockReset();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('reassembles multi-byte UTF-8 characters split across reads', () => {
+    const { dir, file } = tempLog();
+    const listeners = captureWatchListener();
+
+    try {
+      const seen: string[] = [];
+      const stop = followLogFile(file, (line) => seen.push(line));
+
+      const line = `${SCRIPT_LINE} 调用 🦀`;
+      const bytes = Buffer.from(`${line}\n`, 'utf8');
+      // 🦀 is 4 bytes (f0 9f a6 80); the first chunk ends right after its
+      // leading byte, so the character straddles two reads.
+      const cut = bytes.length - 4;
+      fs.appendFileSync(file, bytes.subarray(0, cut));
+      let stat = fs.statSync(file);
+      listeners[0](stat, stat);
+      // No newline has arrived yet: nothing is emitted.
+      expect(seen).toEqual([]);
+
+      fs.appendFileSync(file, bytes.subarray(cut));
+      stat = fs.statSync(file);
+      listeners[0](stat, stat);
+      // The character arrives intact, not as replacement characters.
+      expect(seen).toEqual([line]);
+      stop();
     } finally {
       mockWatchFile.mockReset();
       mockUnwatchFile.mockReset();

--- a/tests/node-quiet-mode.test.ts
+++ b/tests/node-quiet-mode.test.ts
@@ -1,0 +1,131 @@
+import { EventEmitter } from 'events';
+
+const mockSpawn = jest.fn();
+const mockProxyStart = jest.fn();
+const mockProxyStop = jest.fn();
+const mockSubscribe = jest.fn();
+const mockTcpListenAddress = jest.fn();
+const loggerInfo = jest.fn();
+const loggerWarn = jest.fn();
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+jest.mock('../src/node/install', () => ({ installCKBBinary: jest.fn().mockResolvedValue(undefined) }));
+jest.mock('../src/node/init-chain', () => ({
+  initChainIfNeeded: jest.fn().mockResolvedValue(undefined),
+  supportsTerminalRpcModule: () => true,
+  devnetConfigHasTerminalRpc: () => false,
+}));
+jest.mock('../src/cfg/setting', () => ({
+  readSettings: () => ({
+    bins: { defaultCKBVersion: '0.207.0' },
+    devnet: {
+      configPath: '/tmp/offckb-devnet',
+      dataPath: '/tmp/offckb-devnet/data',
+      rpcUrl: 'http://127.0.0.1:8114',
+      rpcProxyPort: 28114,
+      transactionsPath: '/tmp/offckb-devnet/transactions',
+    },
+  }),
+  getCKBBinaryPath: () => '/tmp/ckb',
+}));
+jest.mock('../src/devnet/fork', () => ({ readForkState: () => null }));
+jest.mock('../src/devnet/readiness', () => ({
+  checkNodeReadiness: jest.fn(),
+  waitForNodeReady: jest.fn().mockResolvedValue({ ready: true, rpcUrl: 'http://127.0.0.1:8114' }),
+}));
+jest.mock('../src/tools/rpc-proxy', () => ({
+  createRPCProxy: () => ({ start: mockProxyStart, stop: mockProxyStop }),
+}));
+jest.mock('../src/devnet/log-subscription', () => ({
+  devnetTcpListenAddress: (...args: unknown[]) => mockTcpListenAddress(...args),
+  subscribeToNodeLogs: (...args: unknown[]) => mockSubscribe(...args),
+}));
+jest.mock('../src/util/logger', () => ({
+  logger: {
+    success: jest.fn(),
+    info: (...args: unknown[]) => loggerInfo(...args),
+    warn: (...args: unknown[]) => loggerWarn(...args),
+    debug: jest.fn(),
+    error: jest.fn(),
+    result: jest.fn(),
+  },
+}));
+
+import { nodeDevnet } from '../src/cmd/node';
+import { CkbLogEntry } from '../src/devnet/log-subscription';
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  killed = false;
+  pid = 1234;
+  kill = jest.fn((_signal?: NodeJS.Signals) => {
+    this.killed = true;
+    return true;
+  });
+}
+
+describe('foreground node output modes', () => {
+  let ckb: FakeChild;
+  let miner: FakeChild;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTcpListenAddress.mockReturnValue('127.0.0.1:18114');
+    mockSubscribe.mockReturnValue({ close: jest.fn() });
+    ckb = new FakeChild();
+    miner = new FakeChild();
+    mockSpawn.mockReturnValueOnce(ckb).mockImplementationOnce(() => {
+      process.nextTick(() => miner.emit('spawn'));
+      return miner;
+    });
+  });
+
+  it('does not print node/miner output by default', async () => {
+    await nodeDevnet({});
+    loggerInfo.mockClear();
+    ckb.stdout.emit('data', 'noisy node line');
+    miner.stdout.emit('data', 'noisy miner line');
+    const printed = loggerInfo.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(printed).not.toContain('noisy node line');
+    expect(printed).not.toContain('noisy miner line');
+  });
+
+  it('relays node/miner output when --verbose is set', async () => {
+    await nodeDevnet({ verbose: true });
+    loggerInfo.mockClear();
+    ckb.stdout.emit('data', 'noisy node line');
+    miner.stdout.emit('data', 'noisy miner line');
+    const printed = loggerInfo.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(printed).toContain('noisy node line');
+    expect(printed).toContain('noisy miner line');
+  });
+
+  it('streams ckb-script log entries to the console and hides the rest', async () => {
+    await nodeDevnet({});
+    expect(mockSubscribe).toHaveBeenCalledWith('127.0.0.1:18114', expect.any(Function), expect.any(Function));
+    const onEntry = mockSubscribe.mock.calls[0][1] as (entry: CkbLogEntry) => void;
+
+    onEntry({ message: 'script group: 0xabcd DEBUG OUTPUT: hello', level: 'DEBUG', target: 'ckb-script', date: '' });
+    onEntry({ message: 'block 123', level: 'INFO', target: 'ckb_chain::chain', date: '' });
+
+    const printed = loggerInfo.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(printed).toContain('script group: 0xabcd DEBUG OUTPUT: hello');
+    expect(printed).not.toContain('block 123');
+  });
+
+  it('skips the subscription when the node has no TCP listen address', async () => {
+    mockTcpListenAddress.mockReturnValue(undefined);
+    await nodeDevnet({});
+    expect(mockSubscribe).not.toHaveBeenCalled();
+  });
+
+  it('points the user at offckb logs once the node is ready', async () => {
+    await nodeDevnet({});
+    const printed = loggerInfo.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(printed).toMatch(/offckb logs -f/);
+  });
+});

--- a/tests/node-quiet-mode.test.ts
+++ b/tests/node-quiet-mode.test.ts
@@ -117,6 +117,26 @@ describe('foreground node output modes', () => {
     expect(printed).not.toContain('block 123');
   });
 
+  it('strips terminal control sequences from script log entries', async () => {
+    await nodeDevnet({});
+    const onEntry = mockSubscribe.mock.calls[0][1] as (entry: CkbLogEntry) => void;
+
+    const esc = String.fromCharCode(27);
+    const bel = String.fromCharCode(7);
+    onEntry({
+      message: `${esc}[31mred${esc}[0m ${bel}bell\r`,
+      level: 'DEBUG',
+      target: 'ckb-script',
+      date: '',
+    });
+
+    const printed = loggerInfo.mock.calls.map((args) => args.map(String).join(' ')).join('\n');
+    expect(printed).toContain('red bell');
+    expect(printed).not.toContain(esc);
+    expect(printed).not.toContain(bel);
+    expect(printed).not.toContain('\r');
+  });
+
   it('skips the subscription when the node has no TCP listen address', async () => {
     mockTcpListenAddress.mockReturnValue(undefined);
     await nodeDevnet({});

--- a/tests/node-supervisor.test.ts
+++ b/tests/node-supervisor.test.ts
@@ -45,6 +45,7 @@ jest.mock('../src/util/logger', () => ({
     success: jest.fn(),
     info: jest.fn(),
     warn: jest.fn(),
+    debug: jest.fn(),
     error: jest.fn(),
     result: jest.fn(),
   },

--- a/tests/node-terminal-rpc.test.ts
+++ b/tests/node-terminal-rpc.test.ts
@@ -202,7 +202,7 @@ describe('node devnet Terminal RPC version handling', () => {
     });
 
     await expect(startNode({ network: Network.devnet, binaryPath: '/custom/ckb' })).rejects.toThrow(
-      /^CKB devnet failed to become ready: CKB process exited$/,
+      /^CKB devnet failed to become ready: CKB process exited Check the node log with `offckb logs`/,
     );
   });
 });

--- a/tests/proxy-events.test.ts
+++ b/tests/proxy-events.test.ts
@@ -65,9 +65,16 @@ describe('handleProxyRequestBody', () => {
 });
 
 describe('handleProxyResponseBody', () => {
+  let dir: string;
+  let transactionsPath: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
+    transactionsPath = path.join(dir, 'transactions');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
   it('warns on JSON-RPC errors and records them', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
-    const ctx = makeCtx(path.join(dir, 'transactions'));
+    const ctx = makeCtx(transactionsPath);
     handleProxyResponseBody(
       JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -302, message: 'TransactionFailedToVerify' } }),
       'application/json',
@@ -76,20 +83,28 @@ describe('handleProxyResponseBody', () => {
     expect(ctx.sink.warn).toHaveBeenCalledWith(expect.stringContaining('TransactionFailedToVerify'));
     const content = fs.readFileSync(ctx.events.filePath, 'utf8');
     expect(content).toMatch(/error .*TransactionFailedToVerify/);
-    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('accepts a JSON content type with charset parameters', () => {
+    const ctx = makeCtx(transactionsPath);
+    handleProxyResponseBody(
+      JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -302, message: 'TransactionFailedToVerify' } }),
+      'application/json; charset=utf-8',
+      ctx,
+    );
+    expect(ctx.sink.warn).toHaveBeenCalledWith(expect.stringContaining('TransactionFailedToVerify'));
+    const content = fs.readFileSync(ctx.events.filePath, 'utf8');
+    expect(content).toMatch(/error .*TransactionFailedToVerify/);
   });
 
   it('stays quiet on successful responses', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
-    const ctx = makeCtx(path.join(dir, 'transactions'));
+    const ctx = makeCtx(transactionsPath);
     handleProxyResponseBody(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x0' }), 'application/json', ctx);
     expect(ctx.sink.warn).not.toHaveBeenCalled();
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it('warns for each error entry in a batch response', () => {
-    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
-    const ctx = makeCtx(path.join(dir, 'transactions'));
+    const ctx = makeCtx(transactionsPath);
     handleProxyResponseBody(
       JSON.stringify([
         { jsonrpc: '2.0', id: 1, result: '0x0' },
@@ -100,13 +115,50 @@ describe('handleProxyResponseBody', () => {
     );
     expect(ctx.sink.warn).toHaveBeenCalledTimes(1);
     expect(ctx.sink.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
-    fs.rmSync(dir, { recursive: true, force: true });
   });
 
   it('ignores non-JSON responses', () => {
-    const ctx = makeCtx(path.join(os.tmpdir(), 'transactions'));
+    const ctx = makeCtx(transactionsPath);
     handleProxyResponseBody('<html>not json</html>', 'text/html', ctx);
     expect(ctx.sink.warn).not.toHaveBeenCalled();
     expect(ctx.sink.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('createProxyEventLog', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-log-'));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('writes one line per event even when fields contain newlines or control characters', () => {
+    const file = path.join(dir, 'logs', 'proxy.log');
+    const log = createProxyEventLog(file);
+    const esc = String.fromCharCode(27);
+    log.event(['request get_tip', 'forged'].join('\n') + '\r' + esc + '[31m');
+    const lines = fs.readFileSync(file, 'utf8').trimEnd().split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('request get_tip forged');
+    expect(lines[0]).not.toContain(esc);
+    expect(lines[0]).not.toContain('\r');
+  });
+
+  it('rolls over to a single .1 file once the size cap is exceeded', () => {
+    const file = path.join(dir, 'logs', 'proxy.log');
+    const log = createProxyEventLog(file, 60);
+    log.event('request get_tip_header');
+    log.event('request get_blockchain_info');
+    log.event('request get_tip_header');
+
+    expect(fs.existsSync(`${file}.1`)).toBe(true);
+    // Single rollover: the .1 holds only the previous generation, the live
+    // file only what came after the last rollover.
+    const rolled = fs.readFileSync(`${file}.1`, 'utf8');
+    expect(rolled).toMatch(/get_blockchain_info/);
+    expect(rolled).not.toMatch(/get_tip_header/);
+    const current = fs.readFileSync(file, 'utf8');
+    expect(current).toMatch(/get_tip_header/);
+    expect(current).not.toMatch(/get_blockchain_info/);
   });
 });

--- a/tests/proxy-events.test.ts
+++ b/tests/proxy-events.test.ts
@@ -1,0 +1,112 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { createProxyEventLog, handleProxyRequestBody, handleProxyResponseBody } from '../src/tools/proxy-events';
+
+function makeSink() {
+  const sink = { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() };
+  return sink;
+}
+
+function makeCtx(transactionsPath: string) {
+  return {
+    sink: makeSink(),
+    events: createProxyEventLog(path.join(path.dirname(transactionsPath), 'data', 'logs', 'proxy.log')),
+    transactionsPath,
+    hashTransaction: jest.fn(() => '0xhash'),
+  };
+}
+
+describe('handleProxyRequestBody', () => {
+  let dir: string;
+  let transactionsPath: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
+    transactionsPath = path.join(dir, 'transactions');
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  it('logs ordinary requests at debug level, not info', () => {
+    const ctx = makeCtx(transactionsPath);
+    handleProxyRequestBody(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'get_tip_header', params: [] }), ctx);
+    expect(ctx.sink.debug).toHaveBeenCalledWith('RPC Req: ', 'get_tip_header');
+    expect(ctx.sink.info).not.toHaveBeenCalled();
+  });
+
+  it('records every request in the proxy event log', () => {
+    const ctx = makeCtx(transactionsPath);
+    handleProxyRequestBody(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'get_tip_header', params: [] }), ctx);
+    const content = fs.readFileSync(ctx.events.filePath, 'utf8');
+    expect(content).toMatch(/request get_tip_header/);
+  });
+
+  it('keeps send_transaction hash visible at info and stores the tx file', () => {
+    const ctx = makeCtx(transactionsPath);
+    const tx = { cell_deps: [], inputs: [], outputs: [] };
+    handleProxyRequestBody(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'send_transaction', params: [tx] }), ctx);
+    expect(ctx.sink.info).toHaveBeenCalledWith(expect.stringContaining('0xhash'));
+    expect(fs.existsSync(path.join(transactionsPath, '0xhash.json'))).toBe(true);
+    const content = fs.readFileSync(ctx.events.filePath, 'utf8');
+    expect(content).toMatch(/send_transaction 0xhash/);
+  });
+
+  it('reports malformed JSON-RPC bodies at error level', () => {
+    const ctx = makeCtx(transactionsPath);
+    handleProxyRequestBody('not json', ctx);
+    expect(ctx.sink.error).toHaveBeenCalled();
+  });
+
+  it('ignores empty bodies', () => {
+    const ctx = makeCtx(transactionsPath);
+    handleProxyRequestBody('', ctx);
+    expect(ctx.sink.debug).not.toHaveBeenCalled();
+    expect(ctx.sink.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleProxyResponseBody', () => {
+  it('warns on JSON-RPC errors and records them', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
+    const ctx = makeCtx(path.join(dir, 'transactions'));
+    handleProxyResponseBody(
+      JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -302, message: 'TransactionFailedToVerify' } }),
+      'application/json',
+      ctx,
+    );
+    expect(ctx.sink.warn).toHaveBeenCalledWith(expect.stringContaining('TransactionFailedToVerify'));
+    const content = fs.readFileSync(ctx.events.filePath, 'utf8');
+    expect(content).toMatch(/error .*TransactionFailedToVerify/);
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('stays quiet on successful responses', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
+    const ctx = makeCtx(path.join(dir, 'transactions'));
+    handleProxyResponseBody(JSON.stringify({ jsonrpc: '2.0', id: 1, result: '0x0' }), 'application/json', ctx);
+    expect(ctx.sink.warn).not.toHaveBeenCalled();
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('warns for each error entry in a batch response', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'offckb-proxy-'));
+    const ctx = makeCtx(path.join(dir, 'transactions'));
+    handleProxyResponseBody(
+      JSON.stringify([
+        { jsonrpc: '2.0', id: 1, result: '0x0' },
+        { jsonrpc: '2.0', id: 2, error: { code: -1, message: 'boom' } },
+      ]),
+      'application/json',
+      ctx,
+    );
+    expect(ctx.sink.warn).toHaveBeenCalledTimes(1);
+    expect(ctx.sink.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('ignores non-JSON responses', () => {
+    const ctx = makeCtx(path.join(os.tmpdir(), 'transactions'));
+    handleProxyResponseBody('<html>not json</html>', 'text/html', ctx);
+    expect(ctx.sink.warn).not.toHaveBeenCalled();
+    expect(ctx.sink.error).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 背景

devnet 日志此前有 3 个源(节点/miner/proxy)× 3 个出口(前台转打、daemon.log、status TUI),行为不一致:前台被全量节点输出刷屏,daemon 模式没有内建查看方式,`status` 必须 TTY 全屏。本 PR 按讨论的「方案 A」统一:文件为单一日志源,前台默认安静,新增 `offckb logs` 命令。

## 改动

**1. 新增 `offckb logs [target]`**(`docker logs` 心智,可 pipe、配合 `--json`)
- `offckb logs`(默认)= 节点日志(`run.log`)
- `offckb logs script` = 合约 `debug!` 输出(按 CKB 日志行 target 过滤 `ckb-script`,多行消息的延续行也保留)
- `offckb logs miner` / `offckb logs rpc`
- `-f/--follow`(tail -f 流式)、`--tail N`、`--grep <str>`
- 日志文件在三种运行模式(前台/daemon/status)下都存在,所以任何模式都能看;`daemon` 不作为概念暴露(它是实现残骸),`rpc` 按用户任务命名而非内部架构词 proxy

**2. 前台 `offckb node` 默认安静**
- 不再转打节点/miner 全量 stdout(管道仍会 drain,避免子进程阻塞);`--verbose` 恢复旧行为
- 合约 script debug 输出实时上屏:走节点 TCP log subscription(ckb-tui 同款通道,结构化 entry,非解析 stdout),只显示 `ckb-script`
- 保留高价值单行:`send_transaction: <hash>`、JSON-RPC error warn
- 就绪后提示 `Follow the full node log with: offckb logs -f`

**3. RPC proxy 降噪 + 落盘**
- 每请求 `RPC Req:` 从 info 降为 debug;解析 proxyRes 的 JSON-RPC error 并 warn(此前完全看不到)
- proxy 事件(请求方法 / tx hash / RPC 错误)写入 `data/logs/proxy.log`(前台/daemon 都写),即 `offckb logs rpc` 的数据源

`status` 维持现状;README 已补充 logs 用法。

## 验证

- 新增 4 个测试文件(log 行解析/过滤/tail/follow、logs 命令、proxy 事件、TCP subscription、前台输出模式),全套 271 个 jest 测试通过;`tsc --noEmit`、eslint 干净(lint 的 4 个 warning 为存量)
- 端到端实跑(隔离 XDG 环境,真实 CKB 0.207.0 节点):
  - 前台启动仅输出生命周期 + 提示,出块期间保持安静
  - `logs` / `logs miner` / `logs rpc` 输出正确;`logs -f` 实时流出新块日志
  - 经 proxy deposit → 前台显示 `send_transaction: <hash>`,`logs rpc` 记录 request + hash
  - 注入非法 `send_transaction` → 前台 warn `RPC error: [-32602] ...`,proxy.log 同步记录
  - `--verbose` 恢复 `CKB:`/`CKB-Miner:` 全量输出
  - TCP log subscription 对运行中节点实测有 entry 流
- 已知边界:环境里没有任何调用 `debug!` 的合约(secp256k1 不产生 ckb-script 日志),所以「真实 script entry 上屏」这一环靠单测(entry 过滤+打印)和订阅协议实测覆盖,entry 结构与其余 target 完全一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)