### PR TITLE
chore: bump default CKB version to 0.208.0

### DIFF
--- a/.changeset/tame-bears-bump.md
+++ b/.changeset/tame-bears-bump.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Bump default CKB version to 0.208.0

--- a/src/cfg/setting.ts
+++ b/src/cfg/setting.ts
@@ -66,7 +66,7 @@ export const defaultSettings: Settings = {
   proxy: undefined,
   bins: {
     rootFolder: path.resolve(dataPath, 'bins'),
-    defaultCKBVersion: '0.207.0',
+    defaultCKBVersion: '0.208.0',
     downloadPath: path.resolve(cachePath, 'download'),
   },
   devnet: {


### PR DESCRIPTION
Bump the default CKB binary version in the offckb config from 0.207.0 to [0.208.0](https://github.com/nervosnetwork/ckb/releases/tag/v0.208.0).

- `src/cfg/setting.ts`: `bins.defaultCKBVersion` `0.207.0` → `0.208.0`
- Adds a patch changeset

Verified locally: `tsc --noEmit` clean, full jest suite passes (36 suites, 310 tests), eslint reports only the 4 pre-existing warnings.