### PR TITLE
fix: update ckb-tui download URL to nervosnetwork org repo

### DIFF
--- a/.changeset/ckb-tui-org-repo-url.md
+++ b/.changeset/ckb-tui-org-repo-url.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Update the ckb-tui download URL to the new `nervosnetwork/ckb-tui` org repository after ckb-tui was transferred out of the original personal repo. Release assets moved with the transfer, so the pinned SHA-256 digests still match byte-for-byte and verified installs are unaffected.

--- a/src/tools/ckb-tui.ts
+++ b/src/tools/ckb-tui.ts
@@ -202,7 +202,7 @@ export class CKBTui {
     const binaryName = process.platform === 'win32' ? 'ckb-tui.exe' : 'ckb-tui';
     this.binaryPath = path.join(binDir, binaryName);
 
-    const downloadUrl = `https://github.com/Officeyutong/ckb-tui/releases/download/${version}/${assetName}`;
+    const downloadUrl = `https://github.com/nervosnetwork/ckb-tui/releases/download/${version}/${assetName}`;
 
     // Ensure the target directory exists
     fs.mkdirSync(binDir, { recursive: true });


### PR DESCRIPTION
ckb-tui has been transferred from the personal repo `Officeyutong/ckb-tui` to the org repo [`nervosnetwork/ckb-tui`](https://github.com/nervosnetwork/ckb-tui). As a downstream consumer, offckb's installer needs to download release assets from the new location.

## Changes

- `src/tools/ckb-tui.ts`: point the release download URL at `nervosnetwork/ckb-tui` (the only hardcoded reference to the old repo in the codebase)
- Added a patch changeset

## Verification

- Confirmed via the GitHub API that all releases (v0.1.0–v0.1.4) moved with the transfer and every asset digest matches the digests pinned in `KNOWN_SHA256` byte-for-byte, so the fail-closed checksum gate still passes
- Downloaded `ckb-tui-with-node-linux-amd64.tar.gz` (v0.1.4) from the new URL: SHA-256 `eaed2cfb…01cbd` matches the pinned digest exactly
- `tsc --noEmit` clean; full jest suite green (36 suites, 310 passed / 7 skipped)

The historical `Officeyutong/ckb-tui#13` reference in CHANGELOG.md is intentionally left as-is (released changelog entries are historical records, and GitHub redirects transferred repo links).

🤖 Generated with [Claude Code](https://claude.com/claude-code)