### PR TITLE
fix: strip quotes when splitting ckb-debugger argv (fixes #494) (#495)

### DIFF
--- a/.changeset/debug-tx-file-quotes.md
+++ b/.changeset/debug-tx-file-quotes.md
@@ -1,0 +1,5 @@
+---
+'@offckb/cli': patch
+---
+
+Fix `offckb debug` failing with `ENOENT` on the tx-file path. The debugger now splits its command line quote-aware, so the quotes `encodeBinPathForTerminal` adds around space-containing paths are stripped instead of becoming part of the file name (a regression from the native ckb-debugger switch, which passes array argv to `execFileSync` instead of a shell string).

--- a/src/tools/ckb-debugger.ts
+++ b/src/tools/ckb-debugger.ts
@@ -59,7 +59,20 @@ export class CKBDebugger {
   }
 
   static runRaw(options: string): void {
-    const args = options.split(' ').filter((arg) => arg.trim());
+    // `options` is a space-separated command line whose space-containing
+    // paths are wrapped in quotes by callers (encodeBinPathForTerminal),
+    // which also backslash-escapes embedded double quotes. execFileSync's
+    // array argv does not run through a shell, so a naive split(' ') would
+    // leave the literal quotes in the argument and break such paths. Split
+    // quote-aware instead: a quoted segment stays one argv element, the
+    // surrounding quotes are stripped, and escaped quotes (\") are unescaped.
+    const args =
+      options.match(/"(?:[^"\\]|\\.)*"|\S+/g)?.map((arg) => {
+        if (arg.startsWith('"') && arg.endsWith('"')) {
+          return arg.slice(1, -1).replace(/\\"/g, '"');
+        }
+        return arg;
+      }) ?? [];
     this.execute(args);
   }
 

--- a/src/util/encoding.ts
+++ b/src/util/encoding.ts
@@ -15,5 +15,8 @@ export function setUTF8EncodingForWindows() {
 export function encodeBinPathForTerminal(path: string) {
   // some path contains space in the string
   // this fix the space in the terminal
-  return `"${path}"`;
+  // Escape embedded double quotes: a path containing `"` stays a single
+  // argument both through shell interpolation (execSync) and through the
+  // quote-aware split in CKBDebugger.runRaw.
+  return `"${path.replace(/"/g, '\\"')}"`;
 }

--- a/tests/ckb-debugger.test.ts
+++ b/tests/ckb-debugger.test.ts
@@ -99,3 +99,53 @@ describe('CKBDebugger', () => {
     );
   });
 });
+
+describe('CKBDebugger.runRaw', () => {
+  it('strips quotes from a quoted tx-file path instead of passing them to argv', () => {
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    CKBDebugger.runRaw('--tx-file "/tmp/offckb/devnet/full-transactions/0xabc.json" --cell-index 0');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'ckb-debugger',
+      ['--tx-file', '/tmp/offckb/devnet/full-transactions/0xabc.json', '--cell-index', '0'],
+      expect.anything(),
+    );
+  });
+
+  it('keeps a quoted path containing spaces as a single argv element', () => {
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    CKBDebugger.runRaw('--tx-file "/path/with space/tx.json" --bin "/my bin/ckb"');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'ckb-debugger',
+      ['--tx-file', '/path/with space/tx.json', '--bin', '/my bin/ckb'],
+      expect.anything(),
+    );
+  });
+
+  it('unescapes an embedded quote so the path stays a single argv element', () => {
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    CKBDebugger.runRaw('--tx-file "/path/with\\"quote/tx.json"');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'ckb-debugger',
+      ['--tx-file', '/path/with"quote/tx.json'],
+      expect.anything(),
+    );
+  });
+
+  it('passes unquoted arguments through unchanged', () => {
+    mockSpawnSync.mockReturnValue({ status: 0 });
+
+    CKBDebugger.runRaw('--tx-file /unquoted/path.json --cell-type input');
+
+    expect(mockExecFileSync).toHaveBeenCalledWith(
+      'ckb-debugger',
+      ['--tx-file', '/unquoted/path.json', '--cell-type', 'input'],
+      expect.anything(),
+    );
+  });
+});


### PR DESCRIPTION
* fix: strip quotes when splitting ckb-debugger argv (fixes #494)

offckb debug broke after the native ckb-debugger switch (PR #491): runRaw split the command line on spaces and passed the tokens as array argv to execFileSync, which does not run through a shell. The quotes encodeBinPathForTerminal adds around space-containing paths therefore became literal characters in the file name, so --tx-file "..." failed with ENOENT.

Split quote-aware instead: a quoted segment stays one argv element and the surrounding quotes are stripped.

* fix: handle embedded quotes in ckb-debugger argv paths

encodeBinPathForTerminal now backslash-escapes embedded double quotes, and runRaw's quote-aware split understands escaped quotes (\") inside quoted segments, so a path containing a double quote stays a single argv element instead of being split into pieces with a stray quote.

Addresses CodeRabbit review on PR #495.