### PR TITLE
chore: version packages for 0.4.13 release

### DIFF
--- a/.changeset/balance-commander-errors.md
+++ b/.changeset/balance-commander-errors.md
@@ -1,8 +1,0 @@
----
-'@offckb/cli': patch
----
-
-Fix two CLI UX bugs reported in #498:
-
-- `offckb balance` without an address no longer leaks the SDK's `Unknown address format undefined`. The address argument is now required, so commander prints a clear `error: missing required argument 'toAddress'`.
-- Commander parameter/option errors (unknown option, invalid option value, missing argument) are printed exactly once on stderr instead of twice.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @offckb/cli
 
+## 0.4.13
+
+### Patch Changes
+
+- 0923956: Fix two CLI UX bugs reported in #498:
+
+  - `offckb balance` without an address no longer leaks the SDK's `Unknown address format undefined`. The address argument is now required, so commander prints a clear `error: missing required argument 'toAddress'`.
+  - Commander parameter/option errors (unknown option, invalid option value, missing argument) are printed exactly once on stderr instead of twice.
+
 ## 0.4.12
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@offckb/cli",
-  "version": "0.4.12",
+  "version": "0.4.13",
   "description": "ckb development network for your first try",
   "author": "CKB EcoFund",
   "license": "MIT",


### PR DESCRIPTION
Bump `@offckb/cli` from 0.4.12 to 0.4.13 (patch).

- Consumes the pending `balance-commander-errors` changeset (already marked `patch`), which fixes:
  - `offckb balance` without an address now prints a clear `error: missing required argument 'toAddress'` instead of leaking the SDK's `Unknown address format undefined`.
  - Commander parameter/option errors are printed exactly once on stderr instead of twice.

Changes:
- `package.json`: version `0.4.12` → `0.4.13`
- `CHANGELOG.md`: add 0.4.13 entry
- Remove consumed changeset file