### PR TITLE
fix(canary): append canary suffix without bumping version

### DIFF
--- a/.github/workflows/canary-publish.yml
+++ b/.github/workflows/canary-publish.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Update package version
         run: |
           SHORT_COMMIT_ID=$(git log -1 --pretty=format:%h)
-          npm version prerelease --preid="canary-$SHORT_COMMIT_ID"
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          # Append the canary suffix to the current version without bumping it,
+          # e.g. 0.5.0 -> 0.5.0-canary-<commitid>
+          npm pkg set version="${BASE_VERSION}-canary-${SHORT_COMMIT_ID}"
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
## Summary

The canary release CI currently uses `npm version prerelease --preid="canary-$SHORT_COMMIT_ID"`, which **bumps the patch version** before appending the canary suffix. For example, on version `0.5.0` it publishes a tag like:

- `0.5.1-canary-<commitid>.0`

This change makes the canary tag **not bump** the version. It takes the current version and appends the canary suffix directly, so on `0.5.0` it now publishes:

- `0.5.0-canary-<commitid>`

## How

Replaced `npm version prerelease` with:

```sh
SHORT_COMMIT_ID=$(git log -1 --pretty=format:%h)
BASE_VERSION=$(node -p "require('./package.json').version")
npm pkg set version="${BASE_VERSION}-canary-${SHORT_COMMIT_ID}"
```

`npm pkg set` sets the version field directly without npm-version's bump logic (no patch increment, no trailing `.0` build number). `npm publish --tag canary` consumes the version straight from `package.json`, verified with a dry-run against a local `0.5.0`.

## Verification

- Old behavior (`npm version prerelease --preid=canary-abc123`): `0.5.0 → 0.5.1-canary-abc123.0`
- New behavior (`npm pkg set version=...`): `0.5.0 → 0.5.0-canary-abc123` ✓ (publish dry-run accepted)
