### PR TITLE
feat(fiber): upgrade FNN integration to the final 0.9.0 release

### DIFF
--- a/.changeset/fnn-v090-upgrade.md
+++ b/.changeset/fnn-v090-upgrade.md
@@ -1,0 +1,9 @@
+---
+'@offckb/cli': patch
+---
+
+Upgrade the bundled Fiber (FNN) integration from the `0.9.0-rc` pre-release to the final FNN `v0.9.0` release.
+
+- The default and only downloadable FNN version is now `0.9.0` (was `0.9.0-rc7`); the pinned download SHA-256 digests were re-derived from the `v0.9.0` release tarballs.
+- The `ckb/fiber` submodule is re-pinned to the `v0.9.0` tag commit `e6cb7ac` (was `bc361aa`).
+- The bundled Fiber contracts (`auth`, `funding_lock`, `commitment_lock`) and the `testnet-config.yml` template are byte-identical between `0.9.0-rc7` and `v0.9.0`, and the `node_info` / `connect_peer` / `list_peers` RPC surface plus the `-c` / `-d` / `-s` / `--rpc-enabled-modules` CLI flags offckb uses are unchanged, so no devnet-format or config-generation change was required.

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ secp256k1_multisig_v2:
 	cp ckb/ckb-system-scripts/specs/cells/secp256k1_blake160_multisig_all ckb/devnet/specs/secp256k1_blake160_multisig_all_v2
 
 # Fiber contracts are copied (not rebuilt) from the pinned ckb/fiber submodule
-# (FNN v0.9.0-rc7, fiber commit bc361aa) and committed under
+# (FNN v0.9.0, fiber commit e6cb7ac) and committed under
 # ckb/devnet/specs/fiber/ so published packages work offline; re-run this
 # target after re-pinning the submodule. The upstream binaries embed the
 # builder's home directory in panic metadata, so the copies are sanitized

--- a/README.md
+++ b/README.md
@@ -479,7 +479,7 @@ offckb fiber clean                # delete the whole fiber environment
 - Only the plain local devnet is supported: no mainnet/testnet, and no forked devnet (a `fork.json` present in the devnet directory rejects Fiber startup).
 - A devnet created by an offckb version without Fiber support does not have the Fiber contracts in its genesis. `fiber start` / `node --fiber` on such a devnet refuse with migration guidance: rebuild with `offckb clean` (which deletes the local chain data) and start again; a plain `offckb node` keeps working on the old devnet unchanged.
 - Node `N` uses built-in CKB account `N+2` (accounts 3-18 are reserved for Fiber), RPC port `21713+N` and P2P port `8343+N`. Up to 16 nodes: `offckb fiber start --nodes 4`.
-- `offckb fiber start [FNN-Version]` downloads a tested FNN release (currently `0.9.0-rc7`). Downloaded tarballs are verified against SHA-256 digests pinned in offckb before installation. Use `--binary-path <fnn>` (or `--fnn-binary-path <fnn>` with `node --fiber`) to run a locally built FNN.
+- `offckb fiber start [FNN-Version]` downloads a tested FNN release (currently `0.9.0`). Downloaded tarballs are verified against SHA-256 digests pinned in offckb before installation. Use `--binary-path <fnn>` (or `--fnn-binary-path <fnn>` with `node --fiber`) to run a locally built FNN.
 - Every FNN writes its stdout/stderr to `devnet/fiber/nodes/<id>/fnn.log`, never to your terminal. Per-node FNN config overrides live in `devnet/fiber/nodes.yml` (regenerated `config.yml` files do not keep hand edits). Fields owned by offckb — chain, scripts, listening/bootnode addresses, store path, CKB RPC/UDT wiring, services — are managed and cannot be overridden there.
 - Startup verifies that the devnet spec, the running CKB and every FNN agree on the same chain (genesis hash), and checks each node's identity key, CKB account and available balance before reporting ready.
 - One fiber environment per machine: the RPC/P2P ports are fixed per node id, so a second concurrent fiber environment fails its port check. Note the CKB side of the check is the chain's genesis hash, and every plain offckb devnet shares the same genesis — if you run several offckb environments on one machine (e.g. separate `XDG_DATA_HOME`), make sure `fiber start` attaches to the CKB you actually started for it; when in doubt, check `offckb fiber status` against the environment you mean to use.
@@ -546,7 +546,7 @@ LOG_LEVEL=debug offckb node
 - [x] Nostr-Lock https://github.com/cryptape/nostr-binding/tree/main/contracts/nostr-lock
   - version: 25dd59d
 - [x] Fiber (auth / funding-lock / commitment-lock) https://github.com/nervosnetwork/fiber
-  - commit id: bc361aa (FNN v0.9.0-rc7)
+  - commit id: e6cb7ac (FNN v0.9.0)
 - [x] Type ID built-in
 
 ## Accounts

--- a/src/cfg/setting.ts
+++ b/src/cfg/setting.ts
@@ -68,7 +68,7 @@ export const defaultSettings: Settings = {
   bins: {
     rootFolder: path.resolve(dataPath, 'bins'),
     defaultCKBVersion: '0.208.0',
-    defaultFnnVersion: '0.9.0-rc7',
+    defaultFnnVersion: '0.9.0',
     downloadPath: path.resolve(cachePath, 'download'),
   },
   devnet: {

--- a/src/fiber/install.ts
+++ b/src/fiber/install.ts
@@ -13,7 +13,7 @@ import { logger } from '../util/logger';
 // Only FNN versions tested against the contracts and config rules bundled
 // with this offckb release may be downloaded. Other versions require
 // --binary-path / --fnn-binary-path with a locally built FNN.
-export const SUPPORTED_FNN_VERSIONS = ['0.9.0-rc7'] as const;
+export const SUPPORTED_FNN_VERSIONS = ['0.9.0'] as const;
 export const DEFAULT_FNN_VERSION = SUPPORTED_FNN_VERSIONS[0];
 
 // Independently pinned SHA-256 digests of the upstream release tarballs,
@@ -22,12 +22,12 @@ export const DEFAULT_FNN_VERSION = SUPPORTED_FNN_VERSIONS[0];
 // download is verified against these pins before anything is extracted;
 // a version or package without a pin fails closed.
 export const KNOWN_FNN_SHA256: Record<string, Record<string, string>> = {
-  '0.9.0-rc7': {
-    'fnn_v0.9.0-rc7-x86_64-linux-portable': 'a27627e8cea2304e6075084d2fab72cd1276f512548351d6060e26622cc26faa',
-    'fnn_v0.9.0-rc7-aarch64-linux-portable': 'fc25e907f9f24d345397da5794bac09c03fd76456a0f776bf3377192e3689143',
-    'fnn_v0.9.0-rc7-x86_64-darwin-portable': '3ffa7ca2e3801e2d549c306200ae3add9ee90ec4a5093dfad6fefe04881e107b',
-    'fnn_v0.9.0-rc7-aarch64-darwin-portable': '0127370913d7ec0291c0e1e38a0fff06efb6cdf999bafc87abb5b98e23b5df47',
-    'fnn_v0.9.0-rc7-x86_64-windows': '7c9dd492a481aa18079aef17134bc16e8e247bd0535cb0372ab3476d55cb688b',
+  '0.9.0': {
+    'fnn_v0.9.0-x86_64-linux-portable': '4085453de9a3f7ca0f0aeb7db9e34c0af4d34feb84566be554a5c70557cecbea',
+    'fnn_v0.9.0-aarch64-linux-portable': 'f7b03271d0c8e67cc28dd8ff76876d7740d8ac95a0523764e4846bcef0dcce80',
+    'fnn_v0.9.0-x86_64-darwin-portable': '088410e1db827d2972df752fd5dbb73c90eed8d985a81bc3b3045835f6798640',
+    'fnn_v0.9.0-aarch64-darwin-portable': 'e55720bf167f556ba437b03d0e7c2e3a000c4a9c3d612293be7671fb54168a00',
+    'fnn_v0.9.0-x86_64-windows': 'b9eb9d3a63e082aca9fcdfbe0260b54edbabee987050fde1467fa5fe15b9c480',
   },
 };
 

--- a/tests/fiber-install.test.ts
+++ b/tests/fiber-install.test.ts
@@ -44,26 +44,26 @@ describe('buildFnnDownloadUrl', () => {
 
 describe('buildFnnPackageName', () => {
   it('names the linux/darwin packages for both supported architectures', () => {
-    expect(buildFnnPackageName('0.9.0-rc7', 'linux', 'x64')).toBe('fnn_v0.9.0-rc7-x86_64-linux-portable');
-    expect(buildFnnPackageName('0.9.0-rc7', 'linux', 'arm64')).toBe('fnn_v0.9.0-rc7-aarch64-linux-portable');
-    expect(buildFnnPackageName('0.9.0-rc7', 'darwin', 'x64')).toBe('fnn_v0.9.0-rc7-x86_64-darwin-portable');
-    expect(buildFnnPackageName('0.9.0-rc7', 'darwin', 'arm64')).toBe('fnn_v0.9.0-rc7-aarch64-darwin-portable');
+    expect(buildFnnPackageName('0.9.0', 'linux', 'x64')).toBe('fnn_v0.9.0-x86_64-linux-portable');
+    expect(buildFnnPackageName('0.9.0', 'linux', 'arm64')).toBe('fnn_v0.9.0-aarch64-linux-portable');
+    expect(buildFnnPackageName('0.9.0', 'darwin', 'x64')).toBe('fnn_v0.9.0-x86_64-darwin-portable');
+    expect(buildFnnPackageName('0.9.0', 'darwin', 'arm64')).toBe('fnn_v0.9.0-aarch64-darwin-portable');
   });
 
   it('maps every Windows arch to the only published x86_64 package', () => {
     // FNN publishes no aarch64 Windows build; Windows on ARM runs x64 under
     // emulation, so this mapping is intentional.
-    expect(buildFnnPackageName('0.9.0-rc7', 'win32', 'x64')).toBe('fnn_v0.9.0-rc7-x86_64-windows');
-    expect(buildFnnPackageName('0.9.0-rc7', 'win32', 'arm64')).toBe('fnn_v0.9.0-rc7-x86_64-windows');
+    expect(buildFnnPackageName('0.9.0', 'win32', 'x64')).toBe('fnn_v0.9.0-x86_64-windows');
+    expect(buildFnnPackageName('0.9.0', 'win32', 'arm64')).toBe('fnn_v0.9.0-x86_64-windows');
   });
 
   it('rejects unsupported architectures instead of silently mapping to x86_64', () => {
-    expect(() => buildFnnPackageName('0.9.0-rc7', 'linux', 'ppc64')).toThrow('Unsupported CPU architecture');
-    expect(() => buildFnnPackageName('0.9.0-rc7', 'darwin', 'ia32')).toThrow('Unsupported CPU architecture');
+    expect(() => buildFnnPackageName('0.9.0', 'linux', 'ppc64')).toThrow('Unsupported CPU architecture');
+    expect(() => buildFnnPackageName('0.9.0', 'darwin', 'ia32')).toThrow('Unsupported CPU architecture');
   });
 
   it('rejects unsupported operating systems', () => {
-    expect(() => buildFnnPackageName('0.9.0-rc7', 'freebsd' as NodeJS.Platform, 'x64')).toThrow(
+    expect(() => buildFnnPackageName('0.9.0', 'freebsd' as NodeJS.Platform, 'x64')).toThrow(
       'Unsupported operating system',
     );
   });


### PR DESCRIPTION
## Summary

Adapt offckb's Fiber (FNN) support from the `0.9.0-rc7` pre-release to the final FNN **v0.9.0** release (per [RET-350]).

## What changed

- **Version pins** — `SUPPORTED_FNN_VERSIONS` / `DEFAULT_FNN_VERSION` now target `0.9.0`; `src/cfg/setting.ts` default bumped from `0.9.0-rc7` to `0.9.0`.
- **Download checksums** — the pinned SHA-256 digests were re-derived from the `v0.9.0` release tarballs (they necessarily changed from rc7).
- **`ckb/fiber` submodule** — re-pinned to the `v0.9.0` tag commit `e6cb7ac` (was `bc361aa`/rc7).
- **Docs** — README and Makefile version/commit references updated; a changeset records the release note.
- **Tests** — `fiber-install.test.ts` package-name assertions moved from `0.9.0-rc7` to `0.9.0`.

## Why nothing else needed to change

I diffed the `0.9.0-rc7` → `v0.9.0` transition on the upstream repo:

- The Fiber contracts (`auth`, `funding_lock`, `commitment_lock`) are **byte-identical** between rc7 and v0.9.0.
- The `config/testnet/config.yml` template offckb uses for its devnet is **byte-identical** — already matches offckb's bundled `ckb/devnet/specs/fiber/testnet-config.yml`.
- The RPC surface offckb calls (`node_info`, `connect_peer`, `list_peers`) and the CLI flags it uses (`-c`, `-d`, `-s`, `--rpc-enabled-modules`, `--version`) are unchanged in v0.9.0.

Verified the `0.9.0` binary directly: `fnn --version` prints `0.9.0`, which the existing `getVersionFromBinary` regex matches, and the package layout matches the installer's expectations.

## Validation

- `npx jest tests/fiber-*` — 9 suites / 91 tests pass.
- `npx tsc --noEmit` — clean.
- `npx eslint` on changed files — clean.